### PR TITLE
fix: next i18n text content does not match server-rendered HTML

### DIFF
--- a/src/i18n/index.tsx
+++ b/src/i18n/index.tsx
@@ -1,5 +1,5 @@
 import { createInstance } from "i18next";
-import { useTranslation } from "next-i18next";
+import { useTranslation } from "react-i18next";
 import { useRouter } from "next/router";
 import React, {
   createContext,
@@ -52,10 +52,10 @@ interface TranslateProps {
 
 export function Translate(
   { string, global = false }: TranslateProps,
-): JSX.Element {
+): string {
   const { translator, globalTranslator } = useTranslator();
   const t = global ? globalTranslator : translator;
-  return <span suppressHydrationWarning>{t(string)}</span>;
+  return t(string);
 }
 
 export const T = Translate;


### PR DESCRIPTION
## Description
Updated the import for the next i18n package to a version that is optimized for pages router

<img width="972" alt="image" src="https://github.com/user-attachments/assets/cd867737-ea68-441b-9177-087bf7aba4cd" />
<img width="1417" alt="image" src="https://github.com/user-attachments/assets/15d4bf24-0429-4fcb-9518-64115a755ede" />
