### PR TITLE
fix: disable collapsing markdown when the content is not long enough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ node_modules/
 /blob-report/
 /playwright/.cache/
 .vscode
+.idea

--- a/src/components/atoms/markdown-text.tsx
+++ b/src/components/atoms/markdown-text.tsx
@@ -1,14 +1,14 @@
-import React from "react";
+import React, { forwardRef } from "react";
 import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import rehypeRaw from "rehype-raw";
 
-export function MarkdownText({ data, className }: { data: string, className: string }): JSX.Element {
+export const MarkdownText = forwardRef<HTMLDivElement, { data: string, className?: string }>(function MarkdownText({ data, className }, ref) {
   return (
-    <div className={`markdown-description ${className}`}>
+    <div ref={ref} className={`markdown-description ${className || ""}`}>
       <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw]} >
         {data}
       </Markdown>
     </div>
   );
-}
+});

--- a/src/components/molecules/markdown-collapsable-text.tsx
+++ b/src/components/molecules/markdown-collapsable-text.tsx
@@ -1,17 +1,30 @@
-import React, {useState} from "react";
+import React, {useState, useRef, useEffect} from "react";
 import {T} from "@/i18n";
 import {MarkdownText} from "@/components/atoms/markdown-text.tsx";
 import {Button} from "@mui/material";
 import KeyboardDoubleArrowDown from '@mui/icons-material/KeyboardDoubleArrowDown';
 import KeyboardDoubleArrowUp from '@mui/icons-material/KeyboardDoubleArrowUp';
 
-export function MarkdownCollapsableText({ data, }: { data: string }): JSX.Element {
+const COLLAPSABLE_HEIGHT_DEFAULT = 280;
+interface MarkdowCollapsableTextProps {
+  data: string;
+  collapsableHeight?: number;
+}
+export function MarkdownCollapsableText({ data, collapsableHeight = COLLAPSABLE_HEIGHT_DEFAULT }: MarkdowCollapsableTextProps): JSX.Element {
   const [isCollapsed, setIsCollapsed] = useState(true);
+  const [textHeight, setTextHeight] = useState(0);
+  const markdownTextRef = useRef<HTMLDivElement>(null);
+  const textShouldBeCollapsable = textHeight > collapsableHeight;
+
+  useEffect(() => {
+    setTextHeight((markdownTextRef?.current?.offsetHeight || 0));
+  }, [markdownTextRef?.current]);
+
   return (
     <>
       <div className="overflow-hidden relative">
-        <MarkdownText data={data} className={isCollapsed ? "h-72" : ""} />
-        {!isCollapsed ? "" :
+        <MarkdownText ref={markdownTextRef} data={data} className={isCollapsed && textShouldBeCollapsable ? "h-72" : ""} />
+        {isCollapsed && textShouldBeCollapsable &&
           <div
             className="absolute inset-x-0 bottom-0 z-10 flex h-16 flex-col overflow-hidden"
             style={{
@@ -20,12 +33,12 @@ export function MarkdownCollapsableText({ data, }: { data: string }): JSX.Elemen
           />
         }
       </div>
-      <Button fullWidth color="secondary" onClick={() => setIsCollapsed((oldIsCollapsed) => !oldIsCollapsed)}>
+      {textShouldBeCollapsable && <Button fullWidth color="secondary" onClick={() => setIsCollapsed((oldIsCollapsed) => !oldIsCollapsed)}>
         <div className="flex items-center gap-1 justify-center">
           {isCollapsed ? <KeyboardDoubleArrowDown /> : <KeyboardDoubleArrowUp />}
           <T string={isCollapsed ? "common.showMore" : "common.showLess"} />
         </div>
-      </Button>
+      </Button>}
     </>
   );
 }


### PR DESCRIPTION
### Description
Added conditional rendering of the show more/show less controls on the **MarkdownCollapsableText** component

![image](https://github.com/user-attachments/assets/97282aa6-dda8-4e3a-bd66-7892ccb7fc26)
