### PR TITLE
52 pagination in list pages

### DIFF
--- a/src/hooks/use-pagination.ts
+++ b/src/hooks/use-pagination.ts
@@ -5,7 +5,7 @@ const FIRST_PAGE = 0;
 const ITEMS = 25;
 
 export function usePagination() {
-  const { query, route, push } = useRouter();
+  const { query, push } = useRouter();
   const [page, setPage] = useState(
     parseInt(query.page as string) || FIRST_PAGE,
   );

--- a/src/pages/contract-agreements/index.tsx
+++ b/src/pages/contract-agreements/index.tsx
@@ -1,18 +1,21 @@
-import React, { useEffect, useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
-import { Divider, IconButton } from "@mui/material";
-import { ContractAgreementsList } from "@think-it-labs/edc-connector-ui/contract-agreements-list";
-import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
-import { usePagination } from "@/hooks/use-pagination";
-import { T, useTranslator } from "@/i18n";
-import SideDrawer from "@/components/organisms/side-drawer";
 import ContractAgreementCard from "@/components/organisms/contract-agreement-card";
 import ContractAgreementDialog from "@/components/organisms/contract-agreement-dialog";
-import { ContractAgreement, TransferProcessStates } from "@think-it-labs/edc-connector-client";
-import Typography from "@mui/material/Typography";
-import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client";
-import { AGREEMENT_RETIREMENT_DATE, AGREEMENT_RETIREMENT_REASON, AgreementsRetirementController, RetiredContractAgreement } from "@/utilities/contract-agreement";
+import SideDrawer from "@/components/organisms/side-drawer";
 import { STATE_RUNNING } from "@/constants/transfer-process.ts";
+import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
+import { T, useTranslator } from "@/i18n";
+import { AGREEMENT_RETIREMENT_DATE, AGREEMENT_RETIREMENT_REASON, AgreementsRetirementController, RetiredContractAgreement } from "@/utilities/contract-agreement";
+import { Divider, IconButton } from "@mui/material";
+import Typography from "@mui/material/Typography";
+import { ContractAgreement, TransferProcessStates } from "@think-it-labs/edc-connector-client";
+import { ContractAgreementsList } from "@think-it-labs/edc-connector-ui/contract-agreements-list";
+import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client";
+import { List } from "@think-it-labs/edc-connector-ui/list";
+import { ChevronLeft, ChevronRight } from "lucide-react";
+import { useRouter } from "next/router";
+import { useCallback, useEffect, useState } from "react";
+
+const MAX_ITEMS = 25
 
 interface ContractAgreementInfo {
   [key: string]: {
@@ -30,9 +33,20 @@ export default function ContractAgreementsListPage() {
 
   const { translator } = useTranslator();
 
-  const { decrementPage, incrementPage, offset, limit, hasPrev, page, setHasNext, hasNext } =
-    usePagination();
+  const { push, query } = useRouter()
 
+  const navigate = useCallback((newPage: number) => {
+    push(
+      {
+        href: window.location.href,
+        query: {
+          ...query,
+          page: newPage,
+        },
+      },
+    );
+
+  }, [])
 
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
@@ -106,34 +120,36 @@ export default function ContractAgreementsListPage() {
         contentStyle={{ maxWidth: "90vw", width: "1000px" }}
         translator={translator}
       />
-      <ContractAgreementsList managementUrl={managementUrl}>
+      <ContractAgreementsList managementUrl={managementUrl} usePagination navigate={navigate} currentPage={parseInt(query.page as string) || 0} firstPage={0}>
         <div className="flex justify-between gap-x-5">
           <Typography variant="h4" >
             <T string="contractAgreements.titleConsuming" />
           </Typography>
-
-          <div className="flex justify-end items-center">
-            <div className="inline-flex float-right gap-x-2">
-              <IconButton
-                onClick={decrementPage}
-                disabled={!hasPrev}
-              >
-                <ChevronLeft className="size-6" />
-              </IconButton>
-              <IconButton
-                onClick={incrementPage}
-                disabled={!hasNext}
-              >
-                <ChevronRight className="size-6" />
-              </IconButton>
-            </div>
-          </div>
+          <List.Pagination>
+            {({ decrementPage, hasPrev, hasNext, incrementPage }) =>
+              <div className="flex justify-end items-center">
+                <div className="inline-flex float-right gap-x-2">
+                  <IconButton
+                    onClick={decrementPage}
+                    disabled={!hasPrev}
+                  >
+                    <ChevronLeft className="size-6" />
+                  </IconButton>
+                  <IconButton
+                    onClick={incrementPage}
+                    disabled={!hasNext}
+                  >
+                    <ChevronRight className="size-6" />
+                  </IconButton>
+                </div>
+              </div>
+            }
+          </List.Pagination>
         </div>
 
         <div className="flex flex-wrap gap-4 py-4">
           <ContractAgreementsList.Items
-            limit={limit + 1}
-            offset={offset}
+            limit={MAX_ITEMS}
             sortOrder="DESC"
             filterExpression={[{
               operandLeft: "consumerId",
@@ -141,13 +157,10 @@ export default function ContractAgreementsListPage() {
               operandRight: connector.id
             }]}
           >
-            {({ item, index, items }) => {
-              if (items?.length <= limit) {
-                setHasNext(false)
-              } else {
-                setHasNext(true)
-              }
-              return index < limit ? (
+            {
+              ({ item, index }) =>
+              (
+
                 <ContractAgreementCard
                   key={index}
                   contractAgreement={item}
@@ -156,8 +169,8 @@ export default function ContractAgreementsListPage() {
                   transferCount={contractAgreementInfo[item.id]?.transfersCount}
                   onClick={() => openDetailsModal(item)}
                 />
-              ) : <></>;
-            }}
+              )
+            }
           </ContractAgreementsList.Items >
         </div >
         <ContractAgreementsList.Loading>
@@ -175,33 +188,35 @@ export default function ContractAgreementsListPage() {
 
       <Divider className="!mb-3" />
 
-      <ContractAgreementsList managementUrl={managementUrl}>
+      <ContractAgreementsList managementUrl={managementUrl} usePagination navigate={navigate} currentPage={parseInt(query.page as string) || 0} firstPage={0}>
         <div className="flex justify-between gap-x-5">
           <Typography variant="h4">
             <T string="contractAgreements.titleProviding" />
           </Typography>
-
-          <div className="flex justify-end items-center">
-            <div className="inline-flex float-right gap-x-2">
-              <IconButton
-                onClick={decrementPage}
-                disabled={!hasPrev}
-              >
-                <ChevronLeft className="size-6" />
-              </IconButton>
-              <IconButton
-                onClick={incrementPage}
-              >
-                <ChevronRight className="size-6" />
-              </IconButton>
-            </div>
-          </div>
+          <List.Pagination>
+            {({ decrementPage, hasPrev, hasNext, incrementPage }) =>
+              <div className="flex justify-end items-center">
+                <div className="inline-flex float-right gap-x-2">
+                  <IconButton
+                    onClick={decrementPage}
+                    disabled={!hasPrev}
+                  >
+                    <ChevronLeft className="size-6" />
+                  </IconButton>
+                  <IconButton
+                    onClick={incrementPage}
+                    disabled={!hasNext}
+                  >
+                    <ChevronRight className="size-6" />
+                  </IconButton>
+                </div>
+              </div>}
+          </List.Pagination>
         </div>
 
         <div className="flex flex-wrap gap-4 py-4">
           <ContractAgreementsList.Items
-            limit={limit}
-            offset={offset}
+            limit={MAX_ITEMS}
             sortOrder="DESC"
             filterExpression={[{
               operandLeft: "providerId",
@@ -232,7 +247,7 @@ export default function ContractAgreementsListPage() {
             </span>
           </div>
         </ContractAgreementsList.Loading>
-      </ContractAgreementsList>
+      </ContractAgreementsList >
     </SideDrawer >
   );
 }

--- a/vendors/think-it-labs/edc-connector-ui/src/contract-agreements-list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/contract-agreements-list.tsx
@@ -9,13 +9,29 @@ import { useEdcConnectorClient } from "./hooks/use-edc-connector-client";
 import { List } from "./list";
 import { Local } from "./local";
 
-interface ContractAgreementsListProps {
+interface ContractAgreementsListPropsBase {
   managementUrl: string;
 }
+
+interface ContractAgreementsListPropsWithoutPagination extends ContractAgreementsListPropsBase {
+  usePagination: false;
+}
+
+interface ContractAgreementsListPropsWithPagination extends ContractAgreementsListPropsBase {
+  usePagination: true;
+  currentPage: number;
+  firstPage?: number;
+  navigate: (newPage: number) => void;
+}
+
+type ContractAgreementsListProps =
+  | ContractAgreementsListPropsWithoutPagination
+  | ContractAgreementsListPropsWithPagination;
 
 export function ContractAgreementsList({
   children,
   managementUrl,
+  ...props
 }: PropsWithChildren<ContractAgreementsListProps>) {
   const client = useEdcConnectorClient({
     management: managementUrl,
@@ -27,20 +43,34 @@ export function ContractAgreementsList({
         return client.management.contractAgreements.queryAll(querySpec);
       }
 
-      return Promise.resolve([new ContractAgreement()]) ;
+      return Promise.resolve([new ContractAgreement()]);
     },
     [client],
   );
 
-  return (
-    <List<ContractAgreement>
-      queryAll={queryAll}
-      getId={(contractAgreement: ContractAgreement) => String(contractAgreement.id)}
-      managementUrl={managementUrl}
-    >
-      {children}
-    </List>
-  );
+  if (props.usePagination) {
+    return (
+      <List<ContractAgreement>
+        queryAll={queryAll}
+        getId={(contractAgreement: ContractAgreement) => String(contractAgreement.id)}
+        managementUrl={managementUrl}
+        navigate={props.navigate}
+        page={props.currentPage}
+        usePagination={props.usePagination}
+        firstPage={props.firstPage}
+      >
+        {children}
+      </List>)
+  }
+
+  return (<List<ContractAgreement>
+    queryAll={queryAll}
+    getId={(contractAgreement: ContractAgreement) => String(contractAgreement.id)}
+    managementUrl={managementUrl}
+  >
+    {children}
+  </List>)
+
 }
 
 interface ContractAgreementsListAssetProps {

--- a/vendors/think-it-labs/edc-connector-ui/src/hooks/use-pagination.ts
+++ b/vendors/think-it-labs/edc-connector-ui/src/hooks/use-pagination.ts
@@ -1,0 +1,42 @@
+import { useCallback, useState } from "react";
+
+interface PaginationProps {
+  firstPage?: number,
+  page: number,
+  navigate: (newPage: number) => void
+}
+
+export function usePagination({ firstPage = 0, page, navigate }: PaginationProps) {
+  const [hasNext, setHasNext] = useState(true)
+  const incrementPage = useCallback(
+    () => {
+      const newPage = page + 1;
+      navigate(newPage)
+    },
+    [
+      page,
+      navigate
+    ],
+  );
+
+  const decrementPage = useCallback(
+    () => {
+      const newPage = Math.max(page - 1, firstPage);
+      navigate(newPage)
+    },
+    [
+      page,
+      navigate,
+      firstPage
+    ],
+  );
+
+  return {
+    page,
+    hasPrev: page !== firstPage,
+    hasNext: hasNext,
+    setHasNext: setHasNext,
+    incrementPage,
+    decrementPage,
+  };
+}

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
@@ -1,5 +1,6 @@
 import { QuerySpec } from "@think-it-labs/edc-connector-client";
 import { Context, createContext, useContext } from "react";
+import { usePagination } from "../hooks/use-pagination";
 
 export type ListContext<T> = Context<ListContextType<T>>;
 
@@ -13,6 +14,7 @@ export type ListContextType<T> = {
   deleteItem: (itemId: string) => void;
   getId: (item: T) => string;
   managementUrl: string;
+  pagination?: ReturnType<typeof usePagination>
 };
 
 function createListContext<T>(): ListContext<T> {
@@ -30,3 +32,4 @@ export function useListContext<T>(): ListContextType<T> {
 
   return context;
 }
+

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
@@ -2,22 +2,39 @@ import { CriterionInput, QuerySpec } from "@think-it-labs/edc-connector-client";
 import React, { PropsWithChildren, useEffect, useMemo } from "react";
 import { ListContext, useListContext } from "./list-context";
 import { useList } from "./use-list";
+import { usePagination } from "../hooks/use-pagination";
 
-export interface ListProps<T> {
+export type ListProps<T> = {
   queryAll: (querySpec: QuerySpec) => Promise<T[]>;
   delete?: (id: string) => Promise<void>;
   getId: (item: T) => string;
   managementUrl: string;
+  usePagination?: boolean
+  page?: number
+  navigate?: (newPage: number) => void
+  firstPage?: number
+}
+
+export interface ListProviderProps {
+  page: number;
+  hasPrev: boolean;
+  hasNext: boolean;
+  incrementPage: () => void;
+  decrementPage: () => void;
 }
 
 export function List<T>({
   children,
   queryAll,
   delete: del = async () => {
-    console.warn("delete method not defineds");
+    console.warn("delete method not defined");
   },
   getId,
   managementUrl,
+  usePagination: _usePagination = false,
+  page,
+  navigate,
+  firstPage
 }: PropsWithChildren<ListProps<T>>) {
   const {
     items,
@@ -32,6 +49,8 @@ export function List<T>({
     queryAll,
   });
 
+  const pagination = usePagination({ navigate: navigate || function () { }, page: page || 0, firstPage })
+
   return (
     <ListContext.Provider
       value={{
@@ -44,6 +63,7 @@ export function List<T>({
         triggerSearch: () => triggerSearch(),
         getId,
         managementUrl,
+        pagination: _usePagination ? pagination : null
       } as any}
     >
       {children}
@@ -55,7 +75,6 @@ export interface ListItemProps<T> {
   item: T; // fix: type this
   deleteItem: () => Promise<void>;
   index: number;
-  items: T[]
 }
 
 export interface ListItemsProps<T> {
@@ -75,13 +94,28 @@ List.Items = function ListItems<T,>({
   sortField,
   sortOrder,
 }: ListItemsProps<T>) {
-  const {
+  let {
     items,
     setQuerySpec,
     isLoading,
     deleteItem,
     getId,
+    pagination
   } = useListContext<T>();
+
+  if (pagination && limit) {
+    offset = pagination.page * limit;
+
+    const hasNextPage = items.length > limit;
+    pagination.setHasNext(hasNextPage);
+
+    if (hasNextPage) {
+      items = items.slice(0, limit);
+    }
+
+    limit++
+  }
+
 
   useEffect(() => {
     setQuerySpec({
@@ -101,13 +135,12 @@ List.Items = function ListItems<T,>({
 
   return (
     <>
-      {!isLoading && items.map((item, index, allItems) => (
+      {!isLoading && items.map((item, index) => (
         <Item
           key={getId(item)}
           item={item}
           deleteItem={async () => deleteItem(getId(item))}
           index={index}
-          items={allItems}
         />
       ))}
     </>
@@ -174,3 +207,39 @@ List.SearchTrigger = function ListSearchTrigger(
     </button>
   );
 };
+
+export interface PaginationProps {
+  children: (props: PaginationControlsProps) => JSX.Element;
+}
+
+export interface PaginationControlsProps {
+  page: number
+  hasNext: boolean
+  hasPrev: boolean
+  decrementPage: () => void
+  incrementPage: () => void
+}
+
+List.Pagination = function ({
+  children,
+}: PaginationProps) {
+  const { pagination } = useListContext()
+
+  if (!pagination) {
+    throw Error("Need to use usePagination=true on provider")
+  }
+
+  const PaginationControls = useMemo(() => {
+    return function (props: PaginationControlsProps) {
+      return <>{children(props)}</>;
+    };
+  }, [children]);
+
+  return <PaginationControls
+    page={pagination.page}
+    hasNext={pagination.hasNext}
+    hasPrev={pagination.hasPrev}
+    decrementPage={pagination.decrementPage}
+    incrementPage={pagination.incrementPage}
+  />
+}


### PR DESCRIPTION
## Summary
This PR moves pagination logic from the MDS UI layer to the vendor side. This shift gives us more control over data fetching, allows for easier migration of additional pages, and results in cleaner UI code.

## Implementation Details
- When pagination is enabled, the client requests one extra item to determine if there's a next page. This "peek" item is never rendered but is used internally to infer pagination state.
- A new component, List.Pagination, is introduced to expose pagination controls for clients.
- Page state (e.g., current page number) is left to the client to manage, as implementation can vary depending on the framework or app architecture.
- This PR only migrates the contract-agreements page to the new setup. Once this pattern is approved, I’ll continue migrating the remaining pages accordingly.
- Care has been taken to avoid any API-breaking changes on the vendor side to ensure backward compatibility.

resolves [#82](https://github.com/Mobility-Data-Space/mds-edc-ui/issues/82)
