### PR TITLE
feat: add search to catalog browser

### DIFF
--- a/src/components/organisms/data-offer-card.tsx
+++ b/src/components/organisms/data-offer-card.tsx
@@ -1,15 +1,16 @@
 import React from "react";
 import Typography from "@mui/material/Typography";
-import {Card, CardContent, Chip} from "@mui/material";
-import {Asset, Dataset} from "@think-it-labs/edc-connector-client";
-import {readValue} from "@think-it-labs/edc-connector-ui/json-ld";
-import {AssetIcon} from "@/components/atoms/asset-icon";
+import { Card, CardContent, Chip } from "@mui/material";
+import { Asset, Dataset } from "@think-it-labs/edc-connector-client";
+import { readValue } from "@think-it-labs/edc-connector-ui/json-ld";
+import { AssetIcon } from "@/components/atoms/asset-icon";
 import {
   ASSET_DESCRIPTION,
   ASSET_KEYWORDS,
+  ASSET_TITLE,
   ASSET_VERSION,
 } from "@/schema/asset";
-import {truncate} from "@/utilities/utilities";
+import { truncate } from "@/utilities/utilities";
 import { datasetToAsset } from "@/utilities/catalog";
 
 export interface DataOfferCardProps {
@@ -18,8 +19,8 @@ export interface DataOfferCardProps {
   onClick?: () => void
 }
 
-export default function DataOfferCard({ dataset, participantId, onClick = () => {} }: DataOfferCardProps) {
-  const asset_id = dataset["@id"] ;
+export default function DataOfferCard({ dataset, participantId, onClick = () => { } }: DataOfferCardProps) {
+  const assetTitle = readValue(dataset, ASSET_TITLE)
   const keywords = dataset[ASSET_KEYWORDS] || [];
   const slicedKeywords = keywords.slice(0, 3);
   const remainingKeywordsCount = keywords.length - slicedKeywords.length;
@@ -34,7 +35,7 @@ export default function DataOfferCard({ dataset, participantId, onClick = () => 
           <AssetIcon asset={datasetToAsset(dataset)} fontSize="large" />
           <div className="flex flex-col">
             <Typography variant="h4" className="!leading-none hover:underline cursor-pointer">
-              {asset_id}
+              {assetTitle}
             </Typography>
             <Typography variant="body1" color="textSecondary">
               {participantId}

--- a/src/components/organisms/data-offer-dialog.tsx
+++ b/src/components/organisms/data-offer-dialog.tsx
@@ -1,19 +1,19 @@
-import React, {useState} from "react";
+import React, { useState } from "react";
 import { enqueueSnackbar } from 'notistack';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
 import Typography from "@mui/material/Typography";
-import {Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton} from "@mui/material";
-import {Dataset} from "@think-it-labs/edc-connector-client";
-import {readValue} from "@think-it-labs/edc-connector-ui/json-ld";
-import {AssetIcon} from "@/components/atoms/asset-icon";
+import { Button, Dialog, DialogActions, DialogContent, DialogTitle, IconButton } from "@mui/material";
+import { Dataset } from "@think-it-labs/edc-connector-client";
+import { readValue } from "@think-it-labs/edc-connector-ui/json-ld";
+import { AssetIcon } from "@/components/atoms/asset-icon";
 import DataOfferDetails from "@/components/organisms/data-offer-details";
 import AssetDetails from "@/components/organisms/asset-details";
-import {DeleteDialog} from "@/components/molecules/delete-dialog";
+import { DeleteDialog } from "@/components/molecules/delete-dialog";
 import { T } from "@/i18n";
-import {ASSET_TITLE} from "@/schema/asset";
+import { ASSET_TITLE } from "@/schema/asset";
 import { datasetToAsset } from "@/utilities/catalog";
-import {OnRequestDataOfferDescription} from "@/components/atoms/on-request-data-offer-description.tsx";
+import { OnRequestDataOfferDescription } from "@/components/atoms/on-request-data-offer-description.tsx";
 
 const HAS_POLICY = "http://www.w3.org/ns/odrl/2/hasPolicy";
 
@@ -34,7 +34,7 @@ interface DataOfferDialogProps {
 
 export default function DataOfferDialog({ open, onClose, dataset, onEditClick, deleteEnabled = false, participantId, counterPartyAddress, assetIsOwned = true, deleteItem, onDeleteSuccess, contentStyle = {}, onNegotiateSuccess }: DataOfferDialogProps) {
   const id = dataset["@id"];
-  const title = readValue(dataset.properties, ASSET_TITLE) || "";
+  const title = readValue(dataset, ASSET_TITLE) || "";
   const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
 
   const onDeleteConfirm = async () => {
@@ -68,7 +68,7 @@ export default function DataOfferDialog({ open, onClose, dataset, onEditClick, d
         <DialogTitle>
           <div className="flex flex-row justify-between">
             <div className="flex flex-row gap-x-4 items-center">
-              <AssetIcon asset={datasetToAsset(dataset)} fontSize="large"/>
+              <AssetIcon asset={datasetToAsset(dataset)} fontSize="large" />
               <div className="flex flex-col">
                 <Typography variant="h4">
                   {title}
@@ -82,12 +82,12 @@ export default function DataOfferDialog({ open, onClose, dataset, onEditClick, d
             <div>
               {onEditClick &&
                 <IconButton onClick={onEditClick}>
-                  <EditIcon color="secondary"/>
+                  <EditIcon color="secondary" />
                 </IconButton>
               }
               {deleteEnabled &&
                 <IconButton onClick={() => setDeleteDialogOpen(true)}>
-                  <DeleteIcon color="secondary"/>
+                  <DeleteIcon color="secondary" />
                 </IconButton>
               }
             </div>
@@ -114,7 +114,7 @@ export default function DataOfferDialog({ open, onClose, dataset, onEditClick, d
         </DialogContent>
         <DialogActions>
           <Button color="secondary" onClick={onClose}>
-            <T string="common.close"/>
+            <T string="common.close" />
           </Button>
         </DialogActions>
       </Dialog>

--- a/src/i18n/translations/cn.ts
+++ b/src/i18n/translations/cn.ts
@@ -93,6 +93,7 @@ export const cn = {
       title: "列出所有目录",
       description: "列出所有参与者，您可以检查他们的目录。",
       headingName: "姓名",
+      searchPlaceholder: "按资产标题搜索目录",
       headingStatus: "地位",
       "[participant]": {
         title: "列出合同报价",

--- a/src/i18n/translations/de.ts
+++ b/src/i18n/translations/de.ts
@@ -96,6 +96,7 @@ export const de = {
       description:
         "Listen Sie alle Teilnehmer auf, deren Kataloge Sie einsehen können.",
       headingName: "Name",
+      searchPlaceholder: "Katalog nach Asset-Titel durchsuchen",
       headingStatus: "Status",
       "[participant]": {
         title: "Vertragsangebote für auflisten",

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -309,7 +309,7 @@ export const en = {
       connectorEndpoints: "Connector Endpoints",
       clickForDetails: "Click for details",
       fetchStatus: "Fetch Status",
-      search: "Search Catalog",
+      searchPlaceholder: "Search Catalog By Asset Title",
       otherConnectorEndpointCatalogs: "Other Connector Endpoint Catalogs",
       "[participant]": {
         title: "List contract offers for ",

--- a/src/pages/catalog-browser/index.tsx
+++ b/src/pages/catalog-browser/index.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useState } from "react";
-import { ChevronLeft, ChevronRight } from "lucide-react";
+import { ChevronLeft, ChevronRight, Search } from "lucide-react";
 import LinkIcon from "@mui/icons-material/Link";
 import InfoIcon from "@mui/icons-material/Info";
 import { IconButton, Tooltip } from "@mui/material";
@@ -87,34 +87,6 @@ export default function CatalogPage() {
       />
 
       <SideDrawer title={<T string="catalog.title" />}>
-        <div className="grid grid-cols-3 gap-x-3.5 py-4">
-          <div>
-            <Input
-              id="catalog-url"
-              fullWidth
-              data-testid="catalog-url"
-              type="text"
-              label={<T string="catalog.connectorEndpoints" />}
-              placeholder="https://other-connector.com/"
-              value={counterPartyAddress}
-              slotProps={{
-                input: {
-                  classes: { root: "flex-grow" },
-                  startAdornment: <LinkIcon className="mr-2" />,
-                  endAdornment: <Tooltip title={translator("catalog.clickForDetails")}>
-                    <IconButton onClick={() => setIsCounterPartyAddressDialogOpen(true)}>
-                      <InfoIcon color="primary" />
-                    </IconButton>
-                  </Tooltip>
-                }
-              }}
-              onChange={(event) => {
-                setCounterPartyAddress(event.target.value);
-                debouncedSetCounterPartyAddress(event.target.value);
-              }}
-            />
-          </div>
-        </div>
         <ContractOffersList
           managementUrl={connector.managementUrl}
           counterPartyAddress={counterPartyAddressToSearch}
@@ -123,10 +95,56 @@ export default function CatalogPage() {
           currentPage={parseInt(query.page as string) || 0}
           firstPage={0}
         >
-          <div className="flex justify-end items-center">
+          <div className="w-full grid grid-rows-1 grid-cols-5 gap-x-3.5 py-4 items-center">
+            <div className="col-span-2">
+              <div>
+                <Input
+                  id="catalog-url"
+                  fullWidth
+                  data-testid="catalog-url"
+                  type="text"
+                  label={<T string="catalog.connectorEndpoints" />}
+                  placeholder="https://other-connector.com/"
+                  value={counterPartyAddress}
+                  slotProps={{
+                    input: {
+                      classes: { root: "flex-grow" },
+                      startAdornment: <LinkIcon className="mr-2" />,
+                      endAdornment: <Tooltip title={translator("catalog.clickForDetails")}>
+                        <IconButton onClick={() => setIsCounterPartyAddressDialogOpen(true)}>
+                          <InfoIcon color="primary" />
+                        </IconButton>
+                      </Tooltip>
+                    }
+                  }}
+                  onChange={(event) => {
+                    setCounterPartyAddress(event.target.value);
+                    debouncedSetCounterPartyAddress(event.target.value);
+                  }}
+                />
+              </div>
+            </div>
+            <div className="col-span-2">
+              <div className="relative flex rounded-lg shadow-sm">
+                <ContractOffersList.Search
+                  name="hs-as-table-product-review-search"
+                  className="py-[15px] px-4 ps-11 block w-full border border-black/25 hover:border-black rounded-s-sm text-md focus:z-10 focus:outline-black focus:ring-black disabled:opacity-50 disabled:pointer-events-none"
+                  placeholder={translator("catalog.searchPlaceholder")}
+                  searchOperation="ilike"
+                  searchTarget="http://purl.org/dc/terms/title"
+                />
+                <div className="absolute inset-y-0 start-0 flex items-center pointer-events-none z-20 ps-4">
+                  <Search className="size-5" />
+                </div>
+                <ContractOffersList.SearchTrigger
+                  className="py-3 px-4 inline-flex justify-center items-center gap-x-2 text-black bg-[#ffff26] text-sm font-semibold rounded-e-md border border-transparent  hover:bg-yellow-300 disabled:opacity-50 disabled:pointer-events-none">
+                  <T global string="search" />
+                </ContractOffersList.SearchTrigger>
+              </div>
+            </div>
             <List.Pagination>
               {({ hasNext, incrementPage, hasPrev, decrementPage }) =>
-                <div className="inline-flex float-right gap-x-2">
+                <div className="flex justify-self-end">
                   <IconButton
                     onClick={decrementPage}
                     disabled={!hasPrev}
@@ -148,6 +166,7 @@ export default function CatalogPage() {
               key={listKey}
               limit={MAX_ITEMS}
               sortOrder="DESC"
+
             >
               {({ item, index }) => (
                 <DataOfferCard

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
@@ -1,6 +1,7 @@
 import { QuerySpec } from "@think-it-labs/edc-connector-client";
-import {Context, createContext, ReactNode, useContext} from "react";
+import { Context, createContext, ReactNode, useContext } from "react";
 import { usePagination } from "../hooks/use-pagination";
+import { SearchSpec } from "../types";
 
 export type ListContext<T> = Context<ListContextType<T>>;
 
@@ -8,8 +9,8 @@ export type ListContextType<T> = {
   items: T[];
   isLoading: boolean;
   setQuerySpec: (querySpec: QuerySpec) => void;
-  searchQuery: string;
-  setSearchQuery: (searchQuery: string) => void;
+  searchSpec: SearchSpec;
+  setSearchSpec: (searchSpec: Partial<SearchSpec>) => void;
   triggerSearch: () => void;
   deleteItem: (itemId: string) => void;
   getId: (item: T) => string;

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
@@ -1,6 +1,7 @@
 import { CriterionInput, QuerySpec } from "@think-it-labs/edc-connector-client";
 import React, { PropsWithChildren, ReactNode, useEffect, useMemo } from "react";
 import { usePagination } from "../hooks/use-pagination";
+import { SearchSpec } from "../types";
 import { ListContext, useListContext } from "./list-context";
 import { useList } from "./use-list";
 
@@ -47,8 +48,8 @@ export function List<T>({
     items,
     setQuerySpec,
     isLoading,
-    searchQuery,
-    setSearchQuery,
+    searchSpec,
+    setSearchSpec,
     triggerSearch,
     deleteItem,
   } = useList<T>({
@@ -64,9 +65,10 @@ export function List<T>({
         isLoading,
         items,
         setQuerySpec,
-        searchQuery,
+        searchSpec,
+        setSearchSpec,
         deleteItem: (id: string) => deleteItem(id),
-        setSearchQuery: (value: string) => setSearchQuery(value),
+        setSearchQuery: setSearchSpec,
         triggerSearch: () => triggerSearch(),
         getId,
         managementUrl,
@@ -124,7 +126,6 @@ List.Items = function ListItems<T,>({
 
     limit++
   }
-
 
   useEffect(() => {
     setQuerySpec({
@@ -192,12 +193,18 @@ export interface ListSearchProps {
   placeholder?: string;
   name?: string;
   className?: string;
+  searchTarget?: string
+  searchOperation?: SearchSpec["operator"]
 }
 
 List.Search = function ListSearch(
-  { placeholder, name, className }: ListSearchProps,
+  { placeholder, name, className, searchTarget, searchOperation }: ListSearchProps,
 ) {
-  const { searchQuery, setSearchQuery, triggerSearch } = useListContext();
+  const { searchSpec, setSearchSpec, triggerSearch } = useListContext();
+
+  useEffect(() => {
+    setSearchSpec({ operator: searchOperation, operandLeft: searchTarget })
+  }, [searchTarget, searchOperation])
 
   return (
     <input
@@ -205,13 +212,13 @@ List.Search = function ListSearch(
       name={name}
       className={className}
       placeholder={placeholder}
-      value={searchQuery}
+      value={searchSpec.operandRight}
       onKeyDown={(event) => {
         if (event.key === "Enter") {
           triggerSearch();
         }
       }}
-      onChange={(event) => setSearchQuery(event.currentTarget.value)}
+      onChange={(event) => setSearchSpec({ operandRight: event.currentTarget.value })}
     />
   );
 };

--- a/vendors/think-it-labs/edc-connector-ui/src/list/use-list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/use-list.tsx
@@ -1,13 +1,14 @@
 import { QuerySpec } from "@think-it-labs/edc-connector-client";
 import { useCallback, useEffect, useState } from "react";
+import { SearchSpec } from "../types";
 
 interface ListHook<T> {
   items: T[];
   error: Error | null;
   isLoading: boolean;
   setQuerySpec: (querySpec: QuerySpec) => void;
-  searchQuery: string;
-  setSearchQuery: (query: string) => void;
+  searchSpec: SearchSpec;
+  setSearchSpec: (searchSpec: Partial<SearchSpec>) => void;
   triggerSearch: () => void;
   deleteItem: (id: string) => void;
 }
@@ -21,7 +22,11 @@ export function useList<T>(
   { queryAll, delete: del }: UseListOptions<T>,
 ): ListHook<T> {
   const [querySpec, setQuerySpec] = useState<QuerySpec>({});
-  const [searchQuery, setSearchQuery] = useState<string>("");
+  const [searchSpec, setSearchSpec] = useState<SearchSpec>({
+    operandLeft: "edc:name",
+    operator: "=",
+    operandRight: "",
+  });
   const [items, setItems] = useState<T[]>([]);
   const [error, setError] = useState<Error | null>(null);
   const [isLoading, setLoading] = useState(false);
@@ -73,28 +78,34 @@ export function useList<T>(
     )();
   }, [queryAll, querySpec, shouldSearch]);
 
+  const _setSearchSpec = useCallback((searchSpec: Partial<SearchSpec>) => {
+    setSearchSpec((state) => ({ ...state, ...searchSpec }))
+  }, [])
+
+  const triggerSearch = useCallback(() => {
+    const shouldWrap = searchSpec.operandRight && searchSpec.operator === "ilike" || searchSpec.operator === "like";
+    const operandRight = shouldWrap
+      ? `%${searchSpec.operandRight}%`
+      : searchSpec.operandRight;
+
+    setQuerySpec({
+      ...querySpec,
+      filterExpression: searchSpec.operandRight
+        ? [{ ...searchSpec, operandRight }]
+        : [],
+    });
+
+    setShouldSearch(true);
+  }, [searchSpec, querySpec])
+
   return {
     items,
     error,
     isLoading,
     setQuerySpec,
-    searchQuery,
-    setSearchQuery,
+    searchSpec,
+    setSearchSpec: _setSearchSpec,
     deleteItem,
-    triggerSearch: () => {
-      setQuerySpec({
-        ...querySpec,
-        filterExpression: searchQuery
-          ? [
-            {
-              operandLeft: "edc:name",
-              operator: "=",
-              operandRight: searchQuery,
-            },
-          ]
-          : [],
-      });
-      setShouldSearch(true);
-    },
+    triggerSearch,
   };
 }

--- a/vendors/think-it-labs/edc-connector-ui/src/types.ts
+++ b/vendors/think-it-labs/edc-connector-ui/src/types.ts
@@ -15,3 +15,9 @@ interface ListPropsWithPagination extends ListPropsBase {
 export type ListProps =
   | ListPropsWithoutPagination
   | ListPropsWithPagination;
+
+export interface SearchSpec {
+  operandLeft: string
+  operator: "=" | "!=" | "in" | "like" | "ilike" | "contains"
+  operandRight: string | string[]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -852,7 +852,7 @@
 
 "@types/jsonld@^1.5.15":
   version "1.5.15"
-  resolved "https://registry.npmjs.org/@types/jsonld/-/jsonld-1.5.15.tgz#55dde3077c23986e5f2a3b62356d667bfb03fc71"
+  resolved "https://registry.yarnpkg.com/@types/jsonld/-/jsonld-1.5.15.tgz#55dde3077c23986e5f2a3b62356d667bfb03fc71"
   integrity sha512-PlAFPZjL+AuGYmwlqwKEL0IMP8M8RexH0NIPGfCVWSQ041H2rR/8OlyZSD7KsCVoN8vCfWdtWDBxX8yBVP+xow==
 
 "@types/mdast@^4.0.0":


### PR DESCRIPTION
This pr adds search functionality to the catalog browser by filtering the asset title.


https://github.com/user-attachments/assets/6de3df15-3f10-4390-946d-e94ed4e456d1

The pr adds the ability to set the operandLeft and operator on the search component to choose the search query target and the operation type:

```tsx
<ContractOffersList.Search
  searchOperation="ilike"
  searchTarget="http://purl.org/dc/terms/title"
/>
```