### PR TITLE
fix: remove infinite loop on contract agreements

### DIFF
--- a/src/pages/contract-agreements/index.tsx
+++ b/src/pages/contract-agreements/index.tsx
@@ -135,13 +135,11 @@ export default function ContractAgreementsListPage() {
         setContractAgreementInfo(contractAgreementInfoToSave);
       });
     }).catch(error => enqueueSnackbar("contractAgreements.retiredFetchError"));
-  }, [edcClient, connector, enqueueSnackbar]);
+  }, [edcClient, enqueueSnackbar]);
 
   useEffect(() => {
     populateRetired();
   }, [populateRetired, edcClient]);
-
-  
 
   if (!connector) {
     return "No connector";


### PR DESCRIPTION
This pr removes the infinite loop on the contracts agreements page. It was caused by the connector value re initializing on every render https://github.com/Mobility-Data-Space/MDS-Project/issues/558