### PR TITLE
fix: remove prose class that is causing output issue in asset form

### DIFF
--- a/src/components/organisms/asset-form-general-info-step-content.tsx
+++ b/src/components/organisms/asset-form-general-info-step-content.tsx
@@ -25,7 +25,7 @@ export function AssetFormGeneralInfoStepContent({ translator, formData, onChange
 
   return (
     <div className="flex flex-col gap-y-5">
-      <div className="flex flex-col sm:flex-row gap-2 sm:gap-6 w-full prose">
+      <div className="flex flex-col sm:flex-row gap-2 sm:gap-6 w-full">
         <AssetTitle
           formData={formData}
           errors={errors}


### PR DESCRIPTION
### Description
Version field is not aligned with the rest of the form in asset create form

### Old Screenshot
<img width="836" height="593" alt="image" src="https://github.com/user-attachments/assets/8a863582-31e6-4b50-a24e-79055bea00a8" />


### Fixed screenshot
<img width="867" height="620" alt="image" src="https://github.com/user-attachments/assets/b2811c17-ab64-4b75-84c9-9ddd8f8ca8f1" />
