### PR TITLE
refactor: abstract error component and error list

### DIFF
--- a/src/components/molecules/error-popup.tsx
+++ b/src/components/molecules/error-popup.tsx
@@ -1,0 +1,31 @@
+import { Snackbar } from "@/components/molecules/snackbar";
+import { useTranslator } from "@/i18n";
+import { enqueueSnackbar, useSnackbar } from "notistack";
+
+interface ErrorPopupProps {
+    errorMessageKey: string;
+    errors: Error[] | null;
+}
+
+export function ErrorPopup({ errorMessageKey, errors }: ErrorPopupProps) {
+    const { translator } = useTranslator();
+    const { closeSnackbar } = useSnackbar();
+
+    if (errors && errors.length > 0) {
+        errors.forEach(errorItem => {
+            enqueueSnackbar(translator(errorMessageKey), {
+                variant: "error",
+                content: (key) => (
+                    <Snackbar
+                        type="error"
+                        message={translator(errorMessageKey)}
+                        details={errorItem.message || undefined}
+                        onClose={() => { closeSnackbar(key); }}
+                    />
+                )
+            });
+        });
+    }
+
+    return null;
+}

--- a/src/components/molecules/snackbar.tsx
+++ b/src/components/molecules/snackbar.tsx
@@ -20,7 +20,8 @@ const getSnackbarStyles = (type: SnackbarType) => {
     const baseStyles = {
         fontFamily: 'Sans',
         minWidth: 350,
-        maxWidth: 1500,
+        maxWidth: 600,
+        width: 600,
         display: 'flex',
         alignItems: 'flex-start',
         maxHeight: 300,
@@ -119,7 +120,8 @@ export const Snackbar = forwardRef<HTMLDivElement, SnackbarProps>(
                                     padding: '6px 10px',
                                     maxHeight: 120,
                                     overflowY: 'auto',
-                                    wordBreak: 'break-all',
+                                    wordWrap: 'break-word',
+                                    overflowWrap: 'break-word',
                                     width: '100%'
                                 }}>
                                     {details}

--- a/src/pages/assets/index.tsx
+++ b/src/pages/assets/index.tsx
@@ -5,16 +5,17 @@ import AssetCard from "@/components/organisms/asset-card";
 import AssetDialog from "@/components/organisms/asset-dialog";
 import SideDrawer from "@/components/organisms/side-drawer";
 import AssetFormDialog from "@/components/templates/asset-form-dialog";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
-import { Button as MuiButton, Icon } from '@mui/material';
+import { Icon, Button as MuiButton } from '@mui/material';
 import { Asset } from "@think-it-labs/edc-connector-client";
 import { AssetsList } from "@think-it-labs/edc-connector-ui/assets-list";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
 import { useCallback, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import { proxyConnectorManagement } from "@/constants/proxy";
 
 export default function AssetListPage() {
   const router = useRouter();
@@ -86,22 +87,12 @@ export default function AssetListPage() {
           firstPage={0}
         >
           <AssetsList.Error>
-            {({ error }) => {
-              if (error) {
-                enqueueSnackbar(translator('common.assetsLoadError'), {
-                  variant: "error",
-                  content: (key: any) => (
-                    <Snackbar
-                      type="error"
-                      message={translator('common.assetsLoadError')}
-                      details={error.message || undefined}
-                      onClose={() => { closeSnackbar(key); }}
-                    />
-                  )
-                });
-              }
-              return <></>;
-            }}
+            {({ errors }) =>
+              <ErrorPopup
+                errors={errors}
+                errorMessageKey="common.assetsLoadError"
+              />
+            }
           </AssetsList.Error>
           <div className="flex justify-between pb-6">
             <div className="flex justify-start gap-x-5 items-center">

--- a/src/pages/catalog-browser/index.tsx
+++ b/src/pages/catalog-browser/index.tsx
@@ -1,8 +1,8 @@
 import { Input } from "@/components/atoms/input";
 import { CounterPartyAddressDialog } from "@/components/molecules/counter-party-address-dialog";
+import { ErrorPopup } from "@/components/molecules/error-popup";
 import PaginationControls from "@/components/molecules/pagination-controls";
 import SearchBar from "@/components/molecules/search-bar";
-import { Snackbar } from "@/components/molecules/snackbar";
 import DataOfferCard from "@/components/organisms/data-offer-card";
 import DataOfferDialog from "@/components/organisms/data-offer-dialog";
 import SideDrawer from "@/components/organisms/side-drawer";
@@ -17,14 +17,13 @@ import { Dataset } from "@think-it-labs/edc-connector-client";
 import { ContractOffersList } from "@think-it-labs/edc-connector-ui/contract-offers-list";
 import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client";
 import { useRouter } from "next/router";
-import { enqueueSnackbar, useSnackbar } from "notistack";
+
 import { useCallback, useEffect, useState } from "react";
 import { MAX_ITEMS } from "../../constants/lists";
 
 export default function CatalogPage() {
   const { connector } = useParticipantConnectorState();
   const { translator } = useTranslator();
-  const { closeSnackbar } = useSnackbar();
   const { query } = useRouter();
   const updateQueryParams = useUpdateQueryParams()
 
@@ -57,7 +56,7 @@ export default function CatalogPage() {
 
   const client = useEdcConnectorClient({ management: proxyConnectorManagement });
   useEffect(() => {
-    if(counterPartyAddress){
+    if (counterPartyAddress) {
       client.management.catalog.request({ counterPartyAddress }).then((catalog) => {
         setCatalogParticipantId(catalog["https://w3id.org/dspace/v0.8/participantId"][0]["@value"])
       })
@@ -177,23 +176,14 @@ export default function CatalogPage() {
               </span>
             </div>
           </ContractOffersList.Loading>
-          <ContractOffersList.Error >
-            {({ error }) => {
-              if (error) {
-                enqueueSnackbar(translator('common.catalogLoadError'), {
-                  variant: "error",
-                  content: (key: any) => (
-                    <Snackbar
-                      type="error"
-                      message={translator('common.catalogLoadError')}
-                      details={error.message || undefined}
-                      onClose={() => { closeSnackbar(key); }}
-                    />
-                  )
-                });
-              }
-              return <></>;
-            }}
+
+          <ContractOffersList.Error>
+            {({ errors }) => (
+              <ErrorPopup
+                errors={errors}
+                errorMessageKey="common.catalogLoadError"
+              />
+            )}
           </ContractOffersList.Error>
         </ContractOffersList>
       </SideDrawer>

--- a/src/pages/contract-agreements/index.tsx
+++ b/src/pages/contract-agreements/index.tsx
@@ -5,7 +5,10 @@ import { Snackbar } from "@/components/molecules/snackbar";
 import ContractAgreementCard from "@/components/organisms/contract-agreement-card";
 import ContractAgreementDialog from "@/components/organisms/contract-agreement-dialog";
 import SideDrawer from "@/components/organisms/side-drawer";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
+import { useTerminatedContractAgreements } from "@/hooks/use-terminated-contract-agreements";
+import { useUpdateQueryParams } from "@/hooks/use-update-query-params";
 import { T, useTranslator } from "@/i18n";
 import { theme } from "@/theme/ThemeProvider.tsx";
 import { operatorIn } from "@/utilities/data-offer";
@@ -15,10 +18,8 @@ import { ContractAgreementsList } from "@think-it-labs/edc-connector-ui/contract
 import { useRouter } from "next/router";
 import { SnackbarKey, useSnackbar } from "notistack";
 import { useCallback, useMemo, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import { proxyConnectorManagement } from "@/constants/proxy";
-import { useTerminatedContractAgreements } from "@/hooks/use-terminated-contract-agreements";
-import { useUpdateQueryParams } from "@/hooks/use-update-query-params";
 
 enum StatusFilter {
   All = "All",
@@ -185,22 +186,12 @@ export default function ContractAgreementsListPage() {
         </div>
 
         <ContractAgreementsList.Error>
-          {({ error }) => {
-            if (error) {
-              enqueueSnackbar(translator("common.contractAgreementsLoadError"), {
-                variant: "error",
-                content: (key: any) => (
-                  <Snackbar
-                    type="error"
-                    message={translator('common.contractAgreementsLoadError')}
-                    details={error.message || undefined}
-                    onClose={() => { closeSnackbar(key); }}
-                  />
-                )
-              });
-            }
-            return <></>;
-          }}
+          {({ errors }) =>
+            <ErrorPopup
+              errors={errors}
+              errorMessageKey="common.contractAgreementsLoadError"
+            />
+          }
         </ContractAgreementsList.Error>
 
         <div className="flex flex-col flex-wrap gap-4 py-4" data-testid="contract-agreements-list">

--- a/src/pages/contract-negotiations/index.tsx
+++ b/src/pages/contract-negotiations/index.tsx
@@ -1,25 +1,23 @@
+import { StateChip } from "@/components/atoms/state-chip.tsx";
 import { Table } from "@/components/atoms/table";
-import { Snackbar } from "@/components/molecules/snackbar";
 import PaginationControls from "@/components/molecules/pagination-controls";
 import SearchBar from "@/components/molecules/search-bar";
 import ContractNegotiationDialog from "@/components/organisms/contract-negotiation-dialog";
 import SideDrawer from "@/components/organisms/side-drawer";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
+import { formatDateTime, formatDateTimeAgo } from "@/utilities/date.ts";
+import { Tooltip } from "@mui/material";
 import { ContractNegotiation } from "@think-it-labs/edc-connector-client";
-import {Chip, Tooltip} from "@mui/material";
 import { ContractAgreementView } from "@think-it-labs/edc-connector-ui/contract-agreement-view";
 import { ContractNegotiationsList } from "@think-it-labs/edc-connector-ui/contract-negotiations-list";
 import { readValue } from "@think-it-labs/edc-connector-ui/json-ld.tsx";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
 import { useCallback, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import {formatDateTime, formatDateTimeAgo} from "@/utilities/date.ts";
-import {transferProcessStateColor} from "@/utilities/transfer-process.ts";
-import {StateChip} from "@/components/atoms/state-chip.tsx";
-import {theme} from "@/theme/ThemeProvider.tsx";
-import { proxyConnectorManagement } from "@/constants/proxy";
 
 const CreatedAt = ({ item }: { item: ContractNegotiation }) => {
   const createdAtValue = readValue(item, "https://w3id.org/edc/v0.0.1/ns/createdAt");
@@ -89,22 +87,12 @@ export default function ContractNegotiationsListPage() {
         firstPage={0}
       >
         <ContractNegotiationsList.Error>
-          {({ error }) => {
-            if (error) {
-              enqueueSnackbar(translator('common.contractNegotiationsLoadError'), {
-                variant: "error",
-                content: (key: any) => (
-                  <Snackbar
-                    type="error"
-                    message={translator('common.contractNegotiationsLoadError')}
-                    details={error.message || undefined}
-                    onClose={() => { closeSnackbar(key); }}
-                  />
-                )
-              });
-            }
-            return <></>;
-          }}
+          {({ errors }) =>
+            <ErrorPopup
+              errors={errors}
+              errorMessageKey="common.contractNegotiationsLoadError"
+            />
+          }
         </ContractNegotiationsList.Error>
         <div className="flex justify-between pb-6">
           <div className="flex justify-start gap-x-5 items-center">

--- a/src/pages/data-offers/index.tsx
+++ b/src/pages/data-offers/index.tsx
@@ -1,11 +1,11 @@
 import { TitleWithIcon } from "@/components/atoms/TitleWithIcon";
-import { Snackbar } from "@/components/molecules/snackbar";
 import { JsonLdDialog } from "@/components/molecules/JsonLdDialog";
 import PaginationControls from "@/components/molecules/pagination-controls";
 import SearchBar from "@/components/molecules/search-bar";
 import ContractDefinitionCard from "@/components/organisms/contract-definition-card";
 import DataOfferCreateDialog from "@/components/organisms/data-offer-create-dialog.tsx";
 import SideDrawer from "@/components/organisms/side-drawer";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
 import { Icon, Button as MuiButton } from "@mui/material";
@@ -14,8 +14,8 @@ import { ContractDefinitionsList } from "@think-it-labs/edc-connector-ui/contrac
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
 import { useCallback, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import { proxyConnectorManagement } from "@/constants/proxy";
 
 export default function DataOffersPage() {
   const { push, query } = useRouter()
@@ -79,22 +79,12 @@ export default function DataOffersPage() {
         firstPage={0}
       >
         <ContractDefinitionsList.Error>
-          {({ error }) => {
-            if (error) {
-              enqueueSnackbar(translator("common.dataOffersLoadError"), {
-                variant: "error",
-                content: (key: any) => (
-                  <Snackbar
-                    type="error"
-                    message={translator('common.dataOffersLoadError')}
-                    details={error.message || undefined}
-                    onClose={() => { closeSnackbar(key); }}
-                  />
-                )
-              });
-            }
-            return <></>;
-          }}
+          {({ errors }) =>
+            <ErrorPopup
+              errors={errors}
+              errorMessageKey="common.dataOffersLoadError"
+            />
+          }
         </ContractDefinitionsList.Error>
         <div className="flex justify-between pb-6">
           <div className="flex justify-start gap-x-5">

--- a/src/pages/negotiation-manual-approval/index.tsx
+++ b/src/pages/negotiation-manual-approval/index.tsx
@@ -1,23 +1,22 @@
 import { Table } from "@/components/atoms/table";
-import { Snackbar } from "@/components/molecules/snackbar";
 import PaginationControls from "@/components/molecules/pagination-controls";
+import SearchBar from "@/components/molecules/search-bar";
 import ContractNegotiationDialog from "@/components/organisms/contract-negotiation-dialog";
 import SideDrawer from "@/components/organisms/side-drawer";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
 import { MDSManualApprovalController } from "@/utilities/contract-negotiations";
-import {Button, Icon, Tooltip} from "@mui/material";
+import { formatDateTime, formatDateTimeAgo } from "@/utilities/date.ts";
+import { Button, Icon, Tooltip } from "@mui/material";
 import { ContractNegotiation, CriterionInput } from "@think-it-labs/edc-connector-client";
 import { ContractNegotiationsList } from "@think-it-labs/edc-connector-ui/contract-negotiations-list";
-import { Search } from "lucide-react";
-import SearchBar from "@/components/molecules/search-bar";
+import { readValue } from "@think-it-labs/edc-connector-ui/json-ld.tsx";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
 import { MouseEvent, useCallback, useMemo, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import {readValue} from "@think-it-labs/edc-connector-ui/json-ld.tsx";
-import {formatDateTime, formatDateTimeAgo} from "@/utilities/date.ts";
-import { proxyConnectorManagement } from "@/constants/proxy";
 
 const CreatedAt = ({ item }: { item: ContractNegotiation }) => {
   const createdAtValue = readValue(item, "https://w3id.org/edc/v0.0.1/ns/createdAt");
@@ -114,22 +113,12 @@ export default function ContractNegotiationsManualApprovalListPage() {
         firstPage={0}
       >
         <ContractNegotiationsList.Error>
-          {({ error }) => {
-            if (error) {
-              enqueueSnackbar(translator("common.contractNegotiationsLoadError"), {
-                variant: "error",
-                content: (key: any) => (
-                  <Snackbar
-                    type="error"
-                    message={translator('common.contractNegotiationsLoadError')}
-                    details={error.message || undefined}
-                    onClose={() => { closeSnackbar(key); }}
-                  />
-                )
-              });
-            }
-            return <></>;
-          }}
+          {({ errors }) =>
+            <ErrorPopup
+              errors={errors}
+              errorMessageKey="common.contractNegotiationsLoadError"
+            />
+          }
         </ContractNegotiationsList.Error>
         <div className="flex gap-x-5">
           <div className="flex-grow">

--- a/src/pages/policy-definitions/index.tsx
+++ b/src/pages/policy-definitions/index.tsx
@@ -1,21 +1,22 @@
 import { TitleWithIcon } from "@/components/atoms/TitleWithIcon";
-import { Snackbar } from "@/components/molecules/snackbar";
 import { JsonLdDialog } from "@/components/molecules/JsonLdDialog";
 import PaginationControls from "@/components/molecules/pagination-controls";
 import SearchBar from "@/components/molecules/search-bar";
+import { Snackbar } from "@/components/molecules/snackbar";
 import PolicyCard from "@/components/organisms/policy-card";
 import SideDrawer from "@/components/organisms/side-drawer";
+import { proxyConnectorManagement } from "@/constants/proxy";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
 import { Icon, Button as MuiButton } from "@mui/material";
 import { PolicyDefinition } from "@think-it-labs/edc-connector-client";
+import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client.ts";
 import { PolicyDefinitionsList } from "@think-it-labs/edc-connector-ui/policy-definitions-list";
 import { useRouter } from "next/router";
 import { useSnackbar } from "notistack";
 import { useCallback, useState } from "react";
+import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
-import { proxyConnectorManagement } from "@/constants/proxy";
-import {useEdcConnectorClient} from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client.ts";
 
 export default function PolicyDefinitionListPage() {
   const router = useRouter()
@@ -33,9 +34,11 @@ export default function PolicyDefinitionListPage() {
 
   const openDetailsModal = (policyDefinition: PolicyDefinition) => {
     setIsDetailsModalOpen(true);
-    setOpenPolicyDefinitionData({ policyDefinition, deleteItem: () => {
+    setOpenPolicyDefinitionData({
+      policyDefinition, deleteItem: () => {
         return edcClient.management.policyDefinitions.delete(policyDefinition?.id)
-    } });
+      }
+    });
   };
 
   const navigate = useCallback((newPage: number) => {
@@ -76,7 +79,7 @@ export default function PolicyDefinitionListPage() {
               />
             )
           });
-          setTimeout(() => push("/policy-definitions"), 1000) ;
+          setTimeout(() => push("/policy-definitions"), 1000);
         }}
       />
       <PolicyDefinitionsList
@@ -115,23 +118,14 @@ export default function PolicyDefinitionListPage() {
             </PolicyDefinitionsList.Pagination>
           </div>
         </div>
+
         <PolicyDefinitionsList.Error>
-          {({ error }) => {
-            if (error) {
-              enqueueSnackbar(translator('common.policyDefinitionsLoadError'), {
-                variant: "error",
-                content: (key: any) => (
-                  <Snackbar
-                    type="error"
-                    message={translator('common.policyDefinitionsLoadError')}
-                    details={error.message || undefined}
-                    onClose={() => { closeSnackbar(key); }}
-                  />
-                )
-              });
-            }
-            return <></>;
-          }}
+          {({ errors }) =>
+            <ErrorPopup
+              errors={errors}
+              errorMessageKey="common.policyDefinitionsLoadError"
+            />
+          }
         </PolicyDefinitionsList.Error>
 
         <div className="flex flex-wrap gap-4 py-4" data-testid="policies-list">

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list-context.tsx
@@ -8,7 +8,7 @@ export type ListContext<T> = Context<ListContextType<T>>;
 export type ListContextType<T> = {
   items: T[];
   isLoading: boolean;
-  error: Error | null
+  errors: Error[] | null
   setQuerySpec: (querySpec: QuerySpec) => void;
   searchSpec: SearchSpec;
   setSearchSpec: (searchSpec: Partial<SearchSpec>) => void;

--- a/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/list.tsx
@@ -54,7 +54,7 @@ export function List<T>({
     setSearchSpec,
     triggerSearch,
     deleteItem,
-    error,
+    errors,
   } = useList<T>({
     shouldFetch,
     delete: del,
@@ -67,7 +67,7 @@ export function List<T>({
     <ListContext.Provider
       value={{
         isLoading,
-        error,
+        errors,
         items,
         setQuerySpec,
         searchSpec,
@@ -333,15 +333,15 @@ List.Pagination = function Pagination({
 }
 
 List.Error = function ListError({ children }: {
-  children: (props: { error: Error | null }) => JSX.Element;
+  children: (props: { errors: Error[] | null }) => JSX.Element;
 }) {
-  const { error } = useListContext()
+  const { errors } = useListContext()
 
   const ErrorComponent = useMemo(() => {
-    return function (props: { error: Error | null }) {
+    return function (props: { errors: Error[] | null }) {
       return <>{children(props)}</>;
     };
   }, [children]);
 
-  return <ErrorComponent error={error} />
+  return <ErrorComponent errors={errors} />
 }

--- a/vendors/think-it-labs/edc-connector-ui/src/list/use-list.tsx
+++ b/vendors/think-it-labs/edc-connector-ui/src/list/use-list.tsx
@@ -4,7 +4,7 @@ import { SearchSpec } from "../types";
 
 interface ListHook<T> {
   items: T[];
-  error: Error | null;
+  errors: Error[] | null;
   isLoading: boolean;
   setQuerySpec: (querySpec: QuerySpec) => void;
   searchSpec: SearchSpec;
@@ -23,7 +23,7 @@ type State<T> = {
   baseQuery: QuerySpec;
   searchFilter: SearchSpec;
   items: T[];
-  error: Error | null;
+  errors: Error[] | null;
   isLoading: boolean;
   shouldSearch: boolean;
 };
@@ -34,7 +34,7 @@ type Action<T> =
   | { type: "TRIGGER_SEARCH" }
   | { type: "FETCH_START" }
   | { type: "FETCH_SUCCESS"; payload: T[] }
-  | { type: "FETCH_ERROR"; payload: Error };
+  | { type: "FETCH_ERROR"; payload: Error[] };
 
 const initialSearchFilter: SearchSpec = {
   operandLeft: "edc:name",
@@ -54,13 +54,13 @@ function reducer<T>(state: State<T>, action: Action<T>): State<T> {
       return { ...state, shouldSearch: true };
 
     case "FETCH_START":
-      return { ...state, isLoading: true, error: null };
+      return { ...state, isLoading: true, errors: null };
 
     case "FETCH_SUCCESS":
       return { ...state, isLoading: false, shouldSearch: false, items: action.payload };
 
     case "FETCH_ERROR":
-      return { ...state, isLoading: false, shouldSearch: false, error: action.payload };
+      return { ...state, isLoading: false, shouldSearch: false, errors: action.payload };
 
     default:
       return state;
@@ -188,7 +188,7 @@ export function useList<T>({
     baseQuery: {},
     searchFilter: initialSearchFilter,
     items: [],
-    error: null,
+    errors: null,
     isLoading: false,
     shouldSearch: false,
   });
@@ -206,7 +206,11 @@ export function useList<T>({
 
     const errorMessages = settled
       .filter((r): r is PromiseRejectedResult => r.status === "rejected")
-      .map((r) => (r.reason instanceof Error ? r.reason.message : String(r.reason)));
+      .map(({ reason }) => {
+        return (reason instanceof Error ? reason : new Error(reason))
+      }
+
+      );
 
     const merged = mergeAndDedupeById<T>(fulfilledValues);
     dispatch({ type: "FETCH_SUCCESS", payload: merged });
@@ -214,9 +218,7 @@ export function useList<T>({
     if (errorMessages.length > 0) {
       dispatch({
         type: "FETCH_ERROR",
-        payload: new Error(
-          `Some queries failed (${errorMessages.length}/${queries.length}): ${errorMessages.join("; ")}`
-        ),
+        payload: errorMessages
       });
     }
   }, [queryAll, shouldFetch]);
@@ -257,13 +259,13 @@ export function useList<T>({
       const query = buildFinalQuery(state.baseQuery, state.searchFilter);
       fetchData(query);
     } catch (err) {
-      dispatch({ type: "FETCH_ERROR", payload: toError(err) });
+      dispatch({ type: "FETCH_ERROR", payload: [toError(err)] });
     }
   }, [deleteApi, state.baseQuery, state.searchFilter, fetchData]);
 
   return {
     items: state.items,
-    error: state.error,
+    errors: state.errors,
     isLoading: state.isLoading,
     setQuerySpec,
     searchSpec: state.searchFilter,


### PR DESCRIPTION
This pr enhances the errors component to be more compatible with the [multiple search targets](https://github.com/Mobility-Data-Space/mds-edc-ui/pull/168) model. Additionally, it relocates the error pop-up to a separate, abstract component and reduces the width of the error pop-up.