### PR TITLE
fix: fit popup size to message length

### DIFF
--- a/src/components/molecules/snackbar.tsx
+++ b/src/components/molecules/snackbar.tsx
@@ -19,10 +19,11 @@ export interface SnackbarProps extends SnackbarContentProps {
 const getSnackbarStyles = (type: SnackbarType) => {
     const baseStyles = {
         fontFamily: 'Sans',
-        minWidth: 350,
         maxWidth: 600,
-        width: 600,
-        display: 'flex',
+        width: 'fit-content',
+        display: 'inline-flex',
+        flexGrow: 0,
+        alignSelf: 'flex-start',
         alignItems: 'flex-start',
         maxHeight: 300,
     };


### PR DESCRIPTION
This pr fixes a visual issue where the error message in the pop-up is either too long or too short, which breaks the ui.