### PR TITLE
fix: insure terminated filter works when there are no terminated contracts

### DIFF
--- a/src/pages/contract-agreements/index.tsx
+++ b/src/pages/contract-agreements/index.tsx
@@ -43,11 +43,11 @@ export default function ContractAgreementsListPage() {
   const statusFilterExpression = useMemo(() => ({
     [StatusFilter.All]: undefined,
     [StatusFilter.Active]: undefined,
-    [StatusFilter.Terminated]: retiredContractAgreementIds.length ? {
+    [StatusFilter.Terminated]: {
       operandLeft: "id",
       operator: operatorIn.value,
-      operandRight: retiredContractAgreementIds,
-    } : undefined,
+      operandRight: retiredContractAgreementIds.length ? retiredContractAgreementIds : [""],
+    },
   }), [retiredContractAgreementIds]);
 
   const { enqueueSnackbar, closeSnackbar } = useSnackbar();


### PR DESCRIPTION
The bug happens only if there are no terminated contracts, resulting in an empty retiredContractAgreementIds

Setting the operand right to undefined or an empty string would not work, as this would fail the validation on the backend

The straightforward fix here is to set the operand right to an empty string, as (to my knowledge) the contract agreement ID can't be an empty string (@hciniramy and @ndr-brt is this true ?) 

This is not the most elegant solution; that would be adding the capability to filter contract agreements by their status on the backend.

Side note: This would not affect the case where the fetch for retired contract agreements IDs fails; an empty list will be rendered.

closes #265 