### PR TITLE
fix: remove trailing space from end of Range string

### DIFF
--- a/src/constants/data-category.ts
+++ b/src/constants/data-category.ts
@@ -56,7 +56,7 @@ export const SUBCATEGORIES = {
     'Vehicle Information ',
     'Availability',
     'Location',
-    'Range ',
+    'Range',
   ],
   [INFRASTRUCTURE_AND_LOGISTICS]: [
     'General Information About Planning Of Routes',


### PR DESCRIPTION
There was a typo 🙂

closes #246 