### PR TITLE
Change state colors to match UI theme

### DIFF
--- a/src/constants/transfer-process.ts
+++ b/src/constants/transfer-process.ts
@@ -5,19 +5,19 @@ export const STATE_ERROR = "ERROR";
 export const STATE_FINALIZED = "FINALIZED";
 
 export const COLORS: { [key: string]: string } = {
-  [STATE_RUNNING]: "#7eb0d5",
-  [TransferProcessStates.STARTED]: "#7eb0d5",
-  [TransferProcessStates.DEPROVISIONED]: "#B91C1C",
+  [STATE_RUNNING]: "#FFFF00",
+  [TransferProcessStates.STARTED]: "#FFFF00",
+  [TransferProcessStates.DEPROVISIONED]: "#6E7378",
   [STATE_ERROR]: "#B91C1C",
-  [TransferProcessStates.TERMINATED]: "#FF8C00",
+  [TransferProcessStates.TERMINATED]: "#000000",
   [STATE_FINALIZED]: "#96D200",
 };
 
 export const HOVER_COLORS: { [key: string]: string } = {
-  [STATE_RUNNING]: "#719ec0",
-  [TransferProcessStates.STARTED]: "#719ec0",
-  [TransferProcessStates.DEPROVISIONED]: "#A11818",
+  [STATE_RUNNING]: "#E0E000",
+  [TransferProcessStates.STARTED]: "#E0E000",
+  [TransferProcessStates.DEPROVISIONED]: "#C8CACC",
   [STATE_ERROR]: "#A11818",
-  [TransferProcessStates.TERMINATED]: "#E67E00",
+  [TransferProcessStates.TERMINATED]: "#000000",
   [STATE_FINALIZED]: "#87BD00",
 };


### PR DESCRIPTION
The choice of colors is not perfect, and the available colors are limited
There are 6 states, but 5 colors, and black is the one that makes the most sense for terminated (to me), but does not look pleasing on the dashboard.

Here's the mapping:
running > yellow
started > yellow
deprovisioned > grey
error > red
terminated > black
finalized > green

<img width="1029" height="483" alt="image" src="https://github.com/user-attachments/assets/6c4e5197-855a-4263-be0e-fa59deb228db" />
