### PR TITLE
refactor: use APP_URL for redirecting to app host

### DIFF
--- a/.envrc.example
+++ b/.envrc.example
@@ -17,3 +17,4 @@ export MDS_DAPS_URL="https://daps.mobility-dataspace.eu"
 export MDS_DAPS_JWKS_URL="https://daps.mobility-dataspace.eu/.well-known/jwks.json"
 // Test Config
 export TEST_API_KEY="TEST_API_KEY"
+export APP_URL="http://localhost:3000"

--- a/src/app/connector/management/v3/contractagreements/[...path]/route.ts
+++ b/src/app/connector/management/v3/contractagreements/[...path]/route.ts
@@ -28,11 +28,13 @@ const client = new EdcConnectorClient.Builder()
   .managementUrl(connectorManagmentUrl())
   .build();
 
-const getAgreementsRetirementController = (host: string) =>
-  new AgreementsRetirementController(`${host}${proxyConnectorManagement}`);
+const getAgreementsRetirementController = () => {
+  const newURL = new URL(proxyConnectorManagement, process.env.APP_URL).href;
+  return new AgreementsRetirementController(newURL);
+};
 
 const handlePost = async (req: NextRequest): Promise<NextResponse> => {
-  const { pathname, origin } = req.nextUrl;
+  const { pathname } = req.nextUrl;
   const pathParam = pathname.split("/contractagreements")[1] || "";
 
   if (pathParam.startsWith("/retirements")) {
@@ -76,8 +78,7 @@ const handlePost = async (req: NextRequest): Promise<NextResponse> => {
     );
   }
 
-  const agreementsRetirementController =
-    getAgreementsRetirementController(origin);
+  const agreementsRetirementController = getAgreementsRetirementController();
   const retiredAgreements =
     await agreementsRetirementController.retiredAgreementsRequest();
 


### PR DESCRIPTION
This fixes an issue where the app can't redirect between api routes using the hostname. Instead, we use APP_URL from env vars.