### PR TITLE
fix: transfer process status miss match

### DIFF
--- a/src/components/atoms/state-chip.tsx
+++ b/src/components/atoms/state-chip.tsx
@@ -1,17 +1,39 @@
 import React from "react";
 import { Chip, ChipProps } from "@mui/material";
-import { transferProcessStateBgColor, transferProcessStateTextColor } from "@/utilities/transfer-process.ts";
+import {
+  transferProcessStateBgColor,
+  transferProcessStateTextColor,
+} from "@/utilities/transfer-process.ts";
 
-export function StateChip({ state, icon, ...rest }: { state: string } & ChipProps): JSX.Element {
+export function StateChip({
+  state: _state,
+  icon,
+  didError,
+  ...rest
+}: { state: string; didError: boolean } & ChipProps): JSX.Element {
+  let state = _state;
+  if (state === "DEPROVISIONED") {
+    state = didError ? "TERMINATED" : "COMPLETED";
+  }
 
-  return <Chip
-    className="font-semibold"
-    label={icon ? <span className="flex items-center gap-x-2">{state} {icon}</span> : state}
-    style={{
-      backgroundColor: transferProcessStateBgColor(state),
-      color: transferProcessStateTextColor(state)
-    }}
-    {...rest}
-    icon={undefined}
-  />;
+  return (
+    <Chip
+      className="font-semibold"
+      label={
+        icon ? (
+          <span className="flex items-center gap-x-2">
+            {state} {icon}
+          </span>
+        ) : (
+          state
+        )
+      }
+      style={{
+        backgroundColor: transferProcessStateBgColor(state),
+        color: transferProcessStateTextColor(state),
+      }}
+      {...rest}
+      icon={undefined}
+    />
+  );
 }

--- a/src/components/atoms/transfer-process-icon.tsx
+++ b/src/components/atoms/transfer-process-icon.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Icon, IconProps } from "@mui/material";
 
 import { TransferProcess } from "@think-it-labs/edc-connector-client/dist/src/entities";

--- a/src/components/atoms/transfer-process-state-icon.tsx
+++ b/src/components/atoms/transfer-process-state-icon.tsx
@@ -1,22 +1,26 @@
 import React from "react";
-import {CircularProgress, Icon, IconProps, Tooltip} from "@mui/material";
+import { CircularProgress, Icon, Tooltip } from "@mui/material";
 
-import {Asset} from "@think-it-labs/edc-connector-client";
-import {readValue} from "@think-it-labs/edc-connector-ui/json-ld";
+import { TransferProcess } from "@think-it-labs/edc-connector-client/dist/src/entities";
+import { STATE_ERROR, STATE_RUNNING } from "@/constants/transfer-process.ts";
+import { T } from "@/i18n";
 
-import { DataAddressTypes } from "@/utilities/data-address";
-import {TransferProcess} from "@think-it-labs/edc-connector-client/dist/src/entities";
-import {STATE_ERROR, STATE_RUNNING} from "@/constants/transfer-process.ts";
-import {T} from "@/i18n";
-
-export function TransferProcessStateIcon({ transferProcess }: { transferProcess: TransferProcess }) {
+export function TransferProcessStateIcon({
+  transferProcess,
+}: {
+  transferProcess: TransferProcess;
+}) {
   if (transferProcess.state === STATE_RUNNING) {
     return <CircularProgress size={15} />;
   }
   if (transferProcess.state === STATE_ERROR) {
-    return <Tooltip title={<T string="common.somethingWentWrong" />} >
-      <Icon color="error" style={{ fontSize: "15px" }}>warning</Icon>
-    </Tooltip>;
+    return (
+      <Tooltip title={<T string="common.somethingWentWrong" />}>
+        <Icon color="error" style={{ fontSize: "15px" }}>
+          warning
+        </Icon>
+      </Tooltip>
+    );
   }
 
   return "";

--- a/src/components/organisms/contract-negotiation-details.tsx
+++ b/src/components/organisms/contract-negotiation-details.tsx
@@ -9,48 +9,79 @@ interface ContractNegotiationDetailsProps {
   contractNegotiation: ContractNegotiation;
 }
 
-export default function ContractNegotiationDetails({ contractNegotiation }: ContractNegotiationDetailsProps) {
-  const cleanedContractNegotiation = removeJsonLdSchemaFromProperties(contractNegotiation);
-  const createdAt = formatDateTime(readValue(cleanedContractNegotiation, "createdAt"), { showSeconds: true, showDayOfWeek: true });
-  const counterPartyAddress = readValue(cleanedContractNegotiation, "counterPartyAddress");
-  const counterPartyId = readValue(cleanedContractNegotiation, "counterPartyId");
+export default function ContractNegotiationDetails({
+  contractNegotiation,
+}: ContractNegotiationDetailsProps) {
+  const cleanedContractNegotiation =
+    removeJsonLdSchemaFromProperties(contractNegotiation);
+  const createdAt = formatDateTime(
+    readValue(cleanedContractNegotiation, "createdAt"),
+    { showSeconds: true, showDayOfWeek: true },
+  );
+  const counterPartyAddress = readValue(
+    cleanedContractNegotiation,
+    "counterPartyAddress",
+  );
+  const counterPartyId = readValue(
+    cleanedContractNegotiation,
+    "counterPartyId",
+  );
   const protocol = readValue(cleanedContractNegotiation, "protocol");
   const type = readValue(cleanedContractNegotiation, "type");
 
   return (
     <ul>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldId" /></span>: {contractNegotiation.id}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldId" />
+        </span>
+        : {contractNegotiation.id}
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldContractAgreementId" /></span>: {contractNegotiation.contractAgreementId}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldContractAgreementId" />
+        </span>
+        : {contractNegotiation.contractAgreementId}
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldCounterPartyAddress" /></span>: {counterPartyAddress}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldCounterPartyAddress" />
+        </span>
+        : {counterPartyAddress}
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldCreatedAt" /></span>: {createdAt}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldCreatedAt" />
+        </span>
+        : {createdAt}
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldCounterPartyId" /></span>: <span data-testid="counterparty-id">{counterPartyId}</span>
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldCounterPartyId" />
+        </span>
+        : <span data-testid="counterparty-id">{counterPartyId}</span>
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldProtocol" /></span>: {protocol}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldProtocol" />
+        </span>
+        : {protocol}
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldState"
-        /></span>: <StateChip state={contractNegotiation.state} />
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldState" />
+        </span>
+        :{" "}
+        <StateChip
+          state={contractNegotiation.state}
+          didError={!!contractNegotiation.errorDetail}
+        />
       </li>
       <li className="mt-2">
-        <span className="font-bold"><T
-          string="contractNegotiations.[id].fieldType" /></span>: {type}
+        <span className="font-bold">
+          <T string="contractNegotiations.[id].fieldType" />
+        </span>
+        : {type}
       </li>
     </ul>
   );

--- a/src/components/organisms/transfer-process-table-row.tsx
+++ b/src/components/organisms/transfer-process-table-row.tsx
@@ -1,23 +1,23 @@
-import React, { useEffect, useState } from "react";
+import { StateChip } from "@/components/atoms/state-chip.tsx";
+import { Table } from "@/components/atoms/table.tsx";
+import { TransferProcessIcon } from "@/components/atoms/transfer-process-icon.tsx";
+import { TransferProcessStateIcon } from "@/components/atoms/transfer-process-state-icon.tsx";
+import { JsonLdDialog } from "@/components/molecules/JsonLdDialog.tsx";
+import AssetDialog from "@/components/organisms/asset-dialog.tsx";
+import { useTransferProcessJsonLd } from "@/hooks/use-transfer-process-json-ld.ts";
+import { T } from "@/i18n";
+import { removeJsonLdSchemaFromProperties } from "@/utilities/catalog.ts";
+import { formatDateTime, formatDateTimeAgo } from "@/utilities/date.ts";
 import { Icon, Tooltip } from "@mui/material";
 import {
   Asset,
   ContractAgreement,
   ContractNegotiation,
 } from "@think-it-labs/edc-connector-client";
-import { readValue } from "@think-it-labs/edc-connector-ui/json-ld";
-import { T } from "@/i18n";
-import { Table } from "@/components/atoms/table.tsx";
-import { TransferProcessIcon } from "@/components/atoms/transfer-process-icon.tsx";
-import { TransferProcessStateIcon } from "@/components/atoms/transfer-process-state-icon.tsx";
 import { TransferProcess } from "@think-it-labs/edc-connector-client/dist/src/entities";
-import { removeJsonLdSchemaFromProperties } from "@/utilities/catalog.ts";
 import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client.ts";
-import AssetDialog from "@/components/organisms/asset-dialog.tsx";
-import { JsonLdDialog } from "@/components/molecules/JsonLdDialog.tsx";
-import { useTransferProcessJsonLd } from "@/hooks/use-transfer-process-json-ld.ts";
-import { formatDateTime, formatDateTimeAgo } from "@/utilities/date.ts";
-import { StateChip } from "@/components/atoms/state-chip.tsx";
+import { readValue } from "@think-it-labs/edc-connector-ui/json-ld";
+import { useEffect, useState } from "react";
 
 interface AssetDetailsProps {
   transferProcess: TransferProcess;
@@ -135,6 +135,7 @@ export default function TransferProcessTableRow({
           <div className="flex gap-x-1 items-center">
             <StateChip
               state={transferProcess.state}
+              didError={!!transferProcess.errorDetail}
               icon={
                 <TransferProcessStateIcon transferProcess={transferProcess} />
               }

--- a/src/pages/contract-negotiations/index.tsx
+++ b/src/pages/contract-negotiations/index.tsx
@@ -20,53 +20,69 @@ import { ErrorPopup } from "../../components/molecules/error-popup";
 import { MAX_ITEMS } from "../../constants/lists";
 
 const CreatedAt = ({ item }: { item: ContractNegotiation }) => {
-  const createdAtValue = readValue(item, "https://w3id.org/edc/v0.0.1/ns/createdAt");
-  return <Tooltip title={formatDateTime(createdAtValue, { showSeconds: true, showDayOfWeek: true })}>
-    <span>
-      {formatDateTimeAgo(createdAtValue)}
-    </span>
-  </Tooltip>;
-}
+  const createdAtValue = readValue(
+    item,
+    "https://w3id.org/edc/v0.0.1/ns/createdAt",
+  );
+  return (
+    <Tooltip
+      title={formatDateTime(createdAtValue, {
+        showSeconds: true,
+        showDayOfWeek: true,
+      })}
+    >
+      <span>{formatDateTimeAgo(createdAtValue)}</span>
+    </Tooltip>
+  );
+};
 
 const CounterPartyId = ({ item }: { item: ContractNegotiation }) => {
-  const counterPartyIdValue = readValue(item, "https://w3id.org/edc/v0.0.1/ns/counterPartyId");
-  return <>{counterPartyIdValue}</>
-}
+  const counterPartyIdValue = readValue(
+    item,
+    "https://w3id.org/edc/v0.0.1/ns/counterPartyId",
+  );
+  return <>{counterPartyIdValue}</>;
+};
 
 const CounterPartyAddress = ({ item }: { item: ContractNegotiation }) => {
-  const counterPartyAddressValue = readValue(item, "https://w3id.org/edc/v0.0.1/ns/counterPartyAddress");
-  return <>{counterPartyAddressValue}</>
-}
+  const counterPartyAddressValue = readValue(
+    item,
+    "https://w3id.org/edc/v0.0.1/ns/counterPartyAddress",
+  );
+  return <>{counterPartyAddressValue}</>;
+};
 
 export default function ContractNegotiationsListPage() {
-  const { push, query } = useRouter()
+  const { push, query } = useRouter();
   const { connector } = useParticipantConnectorState();
   const managementUrl = connector?.managementUrl as string;
   const { translator } = useTranslator();
   const [isDetailsModalOpen, setIsDetailsModalOpen] = useState(false);
 
-  const [openContractNegotiationData, setOpenContractNegotiationData] = useState({
-    contractNegotiation: {} as ContractNegotiation,
-  });
+  const [openContractNegotiationData, setOpenContractNegotiationData] =
+    useState({
+      contractNegotiation: {} as ContractNegotiation,
+    });
 
   const openDetailsModal = (contractNegotiation: ContractNegotiation) => {
     setIsDetailsModalOpen(true);
     setOpenContractNegotiationData({ contractNegotiation });
   };
 
-  const currentPage = parseInt(query.page as string) || 0
+  const currentPage = parseInt(query.page as string) || 0;
 
-  const navigate = useCallback((newPage: number) => {
-    push(
-      {
+  const navigate = useCallback(
+    (newPage: number) => {
+      push({
         href: window.location.href,
         query: {
           ...query,
           page: newPage,
         },
-      },
-    );
-  }, [push, query])
+      });
+    },
+    [push, query],
+  );
 
   return (
     <SideDrawer title={<T string="contractNegotiations.title" />}>
@@ -86,22 +102,35 @@ export default function ContractNegotiationsListPage() {
         firstPage={0}
       >
         <ContractNegotiationsList.Error>
-          {({ errors }) =>
+          {({ errors }) => (
             <ErrorPopup
               errors={errors}
               errorMessageKey="common.contractNegotiationsLoadError"
             />
-          }
+          )}
         </ContractNegotiationsList.Error>
         <div className="flex justify-between pb-6">
           <div className="flex justify-start gap-x-5 items-center">
             <div className="min-w-xl">
-              <SearchBar searchTarget="counterPartyId" placeholder={translator("contractNegotiations.searchPlaceholder")} searchOperator="ilike" />
+              <SearchBar
+                searchTarget="counterPartyId"
+                placeholder={translator(
+                  "contractNegotiations.searchPlaceholder",
+                )}
+                searchOperator="ilike"
+              />
             </div>
           </div>
           <div className="flex justify-end items-center">
             <ContractNegotiationsList.Pagination>
-              {({ decrementPage, hasPrev, hasNext, incrementPage, page, itemsCount }) =>
+              {({
+                decrementPage,
+                hasPrev,
+                hasNext,
+                incrementPage,
+                page,
+                itemsCount,
+              }) => (
                 <PaginationControls
                   page={page}
                   hasPrev={hasPrev}
@@ -111,17 +140,18 @@ export default function ContractNegotiationsListPage() {
                   maxItems={MAX_ITEMS}
                   itemsCount={itemsCount}
                 />
-              }
+              )}
             </ContractNegotiationsList.Pagination>
           </div>
         </div>
-        <div className="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center border-t border-gray-200" data-testid="negotiations-list">
+        <div
+          className="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center border-t border-gray-200"
+          data-testid="negotiations-list"
+        >
           <Table>
             <Table.Head>
               <Table.Row>
-                <Table.Heading className="w-16">
-                  #
-                </Table.Heading>
+                <Table.Heading className="w-16">#</Table.Heading>
 
                 <Table.Heading>
                   <T string="contractNegotiations.headingState" />
@@ -159,14 +189,19 @@ export default function ContractNegotiationsListPage() {
                         type="button"
                         className="flex items-center gap-x-2 text-gray-800"
                       >
-                        {(currentPage * 10) + (index + 1)}
+                        {currentPage * 10 + (index + 1)}
                       </button>
                     </Table.Cell>
                     <Table.Cell>
-                      <StateChip state={item.state} />
+                      <StateChip
+                        state={item.state}
+                        didError={!!item.errorDetail}
+                      />
                     </Table.Cell>
                     <Table.Cell>
-                      {!item.contractAgreementId ? "" :
+                      {!item.contractAgreementId ? (
+                        ""
+                      ) : (
                         <ContractAgreementView
                           managementUrl={proxyConnectorManagement}
                           id={item.contractAgreementId}
@@ -179,7 +214,7 @@ export default function ContractNegotiationsListPage() {
                             <ContractAgreementView.Id />
                           </p>
                         </ContractAgreementView>
-                      }
+                      )}
                     </Table.Cell>
                     <Table.Cell>
                       <CounterPartyAddress item={item} />
@@ -206,6 +241,6 @@ export default function ContractNegotiationsListPage() {
           </div>
         </ContractNegotiationsList.Loading>
       </ContractNegotiationsList>
-    </SideDrawer >
+    </SideDrawer>
   );
 }

--- a/src/pages/transfer-processes/index.tsx
+++ b/src/pages/transfer-processes/index.tsx
@@ -17,19 +17,20 @@ export default function TransferProcessesListPage() {
   const { connector } = useParticipantConnectorState();
   const { translator } = useTranslator();
 
-  const currentPage = parseInt(router.query.page as string) || 0
+  const currentPage = parseInt(router.query.page as string) || 0;
 
-  const navigate = useCallback((newPage: number) => {
-    router.push(
-      {
+  const navigate = useCallback(
+    (newPage: number) => {
+      router.push({
         href: window.location.href,
         query: {
           ...router.query,
           page: newPage,
         },
-      },
-    );
-  }, [router])
+      });
+    },
+    [router],
+  );
 
   return (
     <SideDrawer title={<T string="transferProcesses.title" />}>
@@ -43,12 +44,23 @@ export default function TransferProcessesListPage() {
         <div className="flex justify-between pb-6">
           <div className="flex justify-start gap-x-5 items-center">
             <div className="min-w-xl">
-              <SearchBar searchTarget="assetId" placeholder={translator("transferProcesses.searchPlaceholder")} searchOperator="ilike" />
+              <SearchBar
+                searchTarget="assetId"
+                placeholder={translator("transferProcesses.searchPlaceholder")}
+                searchOperator="ilike"
+              />
             </div>
           </div>
           <div className="flex justify-end items-center">
             <TransferProcessesList.Pagination>
-              {({ decrementPage, hasPrev, hasNext, incrementPage, page, itemsCount }) =>
+              {({
+                decrementPage,
+                hasPrev,
+                hasNext,
+                incrementPage,
+                page,
+                itemsCount,
+              }) => (
                 <PaginationControls
                   page={page}
                   hasPrev={hasPrev}
@@ -59,12 +71,15 @@ export default function TransferProcessesListPage() {
                   dataTestIdPrefix="pagination"
                   itemsCount={itemsCount}
                 />
-              }
+              )}
             </TransferProcessesList.Pagination>
           </div>
         </div>
 
-        <div className="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center border-t border-gray-200" data-testid="transfer-processes-list">
+        <div
+          className="px-6 py-4 grid gap-3 md:flex md:justify-between md:items-center border-t border-gray-200"
+          data-testid="transfer-processes-list"
+        >
           <Table>
             <Table.Head>
               <Table.Row>


### PR DESCRIPTION
closes #266 
This is suggested by Andrea:
On the provider side, transfer processes automatically move to the deprovisioned state, but the consumer has manually triggered the deprovisioning process, and that is the cause of the mismatch. There's no direct way to know the previous state of a deprovisioned transfer. What we can do is guess based on whether or not the transfer process has an `errorDetails` property. This is not 100% accurate, but it's close enough (90%)