### PR TITLE
fix: fetch only today ids

### DIFF
--- a/src/hooks/use-generate-next-contract-definition-id.ts
+++ b/src/hooks/use-generate-next-contract-definition-id.ts
@@ -1,0 +1,71 @@
+import { proxyConnectorManagement } from "@/constants/proxy";
+import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client";
+
+import { useState, useEffect } from "react";
+
+type NextContractDefinitionId = {
+  error: null;
+  id: string;
+} & {
+  error: string;
+  id: null;
+};
+
+export const useGenerateNextContractDefinitionId =
+  (): NextContractDefinitionId => {
+    const [id, setId] = useState<string | null>(null);
+    const [error, setError] = useState<string | null>(null);
+
+    const client = useEdcConnectorClient({
+      management: proxyConnectorManagement,
+    });
+
+    useEffect(() => {
+      const generateId = async () => {
+        try {
+          setError(null);
+
+          const prefix = "mds-data-offer-";
+          const now = new Date();
+          const day = String(now.getDate()).padStart(2, "0");
+          const month = String(now.getMonth() + 1).padStart(2, "0");
+          const year = now.getFullYear();
+          const datePrefix = `${day}${month}${year}`;
+
+          const existingTodayIds = (
+            await client.management.contractDefinitions.queryAll({
+              offset: 0,
+              limit: 1000,
+              filterExpression: [
+                {
+                  operandLeft: "id",
+                  operator: "like",
+                  operandRight: `${prefix}${datePrefix}_%`,
+                },
+              ],
+            })
+          ).map((contract) => contract["@id"]);
+
+          const maxUid = existingTodayIds
+            .filter((id) => id.startsWith(`${prefix}${datePrefix}_`))
+            .map((id) => {
+              const uidPart = id.substring(`${prefix}${datePrefix}_`.length);
+              return parseInt(uidPart, 10);
+            })
+            .filter((uid) => !isNaN(uid))
+            .reduce((max, uid) => Math.max(max, uid), 0);
+
+          const nextUid = maxUid + 1;
+          console.log("next uid is ", nextUid);
+
+          setId(`${prefix}${datePrefix}_${nextUid}`);
+        } catch (err) {
+          setError(err as string);
+        }
+      };
+
+      generateId();
+    }, [client]);
+
+    return { nextId: id, error } as NextContractDefinitionId;
+  };

--- a/src/i18n/translations/en.ts
+++ b/src/i18n/translations/en.ts
@@ -441,6 +441,8 @@ export const en = {
       publishDataOffer: "Publish Data Offer",
       searchPlaceholder: "Search Data Offers by Offer ID",
       deleteSuccess: "Data offer deleted successfully!",
+      failedToFetch:
+        "failed to load contract definitions, Please try again later",
       "[id]": {
         title: "View data offer",
         deleteButton: "Delete",

--- a/src/pages/create-data-offer/index.tsx
+++ b/src/pages/create-data-offer/index.tsx
@@ -83,6 +83,7 @@ import {
 import { useEdcConnectorClient } from "@think-it-labs/edc-connector-ui/hooks/use-edc-connector-client";
 import { useSnackbar } from "notistack";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useGenerateNextContractDefinitionId } from "@/hooks/use-generate-next-contract-definition-id";
 
 interface DataOffer {
   asset: AssetInput;
@@ -136,14 +137,30 @@ export default function CreateDataOfferPage() {
       );
   }, [client, setExistingIds, setExistingContractIds]);
 
+  const { nextId, error: generateIdError } =
+    useGenerateNextContractDefinitionId();
+
   // Update contract ID when existing contracts are loaded
   useEffect(() => {
-    if (existingContractIds) {
-      setFormData((prev) => ({
-        ...prev,
-        contract: createDefaultContractDefinitionFormData(existingContractIds),
-      }));
+    if (generateIdError) {
+      enqueueSnackbar("", {
+        content: (key) => (
+          <Snackbar
+            type="error"
+            message={translator("contractDefinitions.failedToFetch")}
+            onClose={() => {
+              closeSnackbar(key);
+            }}
+          />
+        ),
+      });
+      return;
     }
+
+    setFormData((prev) => ({
+      ...prev,
+      contract: createDefaultContractDefinitionFormData(nextId),
+    }));
   }, [existingContractIds]);
 
   const generalInfoIsNotValid = () => {

--- a/src/utilities/contract-definition.ts
+++ b/src/utilities/contract-definition.ts
@@ -1,25 +1,32 @@
-import {removeEmptyFields} from "@/utilities/form";
+import { removeEmptyFields } from "@/utilities/form";
 import { ContractDefinitionInput } from "@think-it-labs/edc-connector-client";
 import { generateDataOfferId } from "@/utilities/data-offer";
 
-export type MdsContractDefinitionInput = ContractDefinitionInput & { privateProperties: { manualApproval: boolean } };
+export type MdsContractDefinitionInput = ContractDefinitionInput & {
+  privateProperties: { manualApproval: boolean };
+};
 
-export const fromContractDefinitionForm = (formData: MdsContractDefinitionInput): MdsContractDefinitionInput => {
+export const fromContractDefinitionForm = (
+  formData: MdsContractDefinitionInput,
+): MdsContractDefinitionInput => {
   const cleanFormDataObject = removeEmptyFields(formData);
-  return cleanFormDataObject as MdsContractDefinitionInput
+  return cleanFormDataObject as MdsContractDefinitionInput;
 };
 
-export const defaultCreateContractDefinitionFormData: MdsContractDefinitionInput = {
-  "@id": "", 
-  accessPolicyId: "",
-  contractPolicyId: "",
-  assetsSelector: [],
-  privateProperties: {
-    manualApproval: false
-  }
-};
+export const defaultCreateContractDefinitionFormData: MdsContractDefinitionInput =
+  {
+    "@id": "",
+    accessPolicyId: "",
+    contractPolicyId: "",
+    assetsSelector: [],
+    privateProperties: {
+      manualApproval: false,
+    },
+  };
 
-export const createDefaultContractDefinitionFormData = (existingIds: string[] = []): MdsContractDefinitionInput => ({
+export const createDefaultContractDefinitionFormData = (
+  id: string,
+): MdsContractDefinitionInput => ({
   ...defaultCreateContractDefinitionFormData,
-  "@id": generateDataOfferId(existingIds)
+  "@id": id,
 });

--- a/src/utilities/data-offer.ts
+++ b/src/utilities/data-offer.ts
@@ -1,23 +1,26 @@
-import {CriterionInput, EdcConnectorClient} from "@think-it-labs/edc-connector-client";
+import {
+  CriterionInput,
+  EdcConnectorClient,
+} from "@think-it-labs/edc-connector-client";
 
-export const EDC_ID_FIELD = "https://w3id.org/edc/v0.0.1/ns/id"
+export const EDC_ID_FIELD = "https://w3id.org/edc/v0.0.1/ns/id";
 
 export const operatorEqual = {
-  value: '=',
-  text: 'Equal',
-  tooltip: 'Equal',
+  value: "=",
+  text: "Equal",
+  tooltip: "Equal",
 };
 
 export const operatorLike = {
-  value: 'like',
-  text: 'Like',
-  tooltip: 'Like',
+  value: "like",
+  text: "Like",
+  tooltip: "Like",
 };
 
 export const operatorIn = {
-  value: 'in',
-  text: 'In',
-  tooltip: 'In',
+  value: "in",
+  text: "In",
+  tooltip: "In",
 };
 
 export const idSelector = (id: string): CriterionInput[] => {
@@ -25,9 +28,9 @@ export const idSelector = (id: string): CriterionInput[] => {
     {
       operandLeft: EDC_ID_FIELD,
       operator: operatorIn.value,
-      operandRight: id
-    }
-  ]
+      operandRight: id,
+    },
+  ];
 };
 
 export const idMultipleSelector = (ids: string[]): CriterionInput[] => {
@@ -35,9 +38,9 @@ export const idMultipleSelector = (ids: string[]): CriterionInput[] => {
     {
       operandLeft: EDC_ID_FIELD,
       operator: operatorIn.value,
-      operandRight: transformIdsToString(ids)
-    }
-  ]
+      operandRight: transformIdsToString(ids),
+    },
+  ];
 };
 
 export const transformIdsToString = (ids: string[]): string => {
@@ -46,27 +49,4 @@ export const transformIdsToString = (ids: string[]): string => {
 
 export const idMultipleReader = (criteria: CriterionInput[]): string[] => {
   return criteria?.at(0)?.operandRight.split(",") || [];
-}
-
-export const generateDataOfferId = (existingIds: string[] = []): string => {
-  const prefix = "mds-data-offer-";
-  const now = new Date();
-  const day = String(now.getDate()).padStart(2, '0');
-  const month = String(now.getMonth() + 1).padStart(2, '0');
-  const year = now.getFullYear();
-  const datePrefix = `${day}${month}${year}`;
-
-  // Find existing IDs for today - only look at mds-data-offer IDs for the current date
-  const todayIds = existingIds
-    .filter(id => id.startsWith(`${prefix}${datePrefix}_`))
-    .map(id => {
-      const uidPart = id.substring(`${prefix}${datePrefix}_`.length);
-      return parseInt(uidPart, 10);
-    })
-    .filter(uid => !isNaN(uid))
-    .sort((a, b) => b - a); // Sort descending to get highest first
-  
-  const nextUid = todayIds.length > 0 ? todayIds[0] + 1 : 1;
-  console.log("next uid is ", nextUid)
-  return `${prefix}${datePrefix}_${nextUid}`;
 };


### PR DESCRIPTION
The issue was caused by the contract definition query hitting the default 50 limit.
Changing the default to 100 and only fetching today's IDs should fix this for good.
closes #281 