### PR TITLE
feat: fetch asset title for provider contract agreements

### DIFF
--- a/src/app/connector/management/v3/contractagreements/[...path]/route.ts
+++ b/src/app/connector/management/v3/contractagreements/[...path]/route.ts
@@ -1,6 +1,9 @@
+import { CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS } from "@/constants/contract-agreement";
 import { proxyConnectorManagement } from "@/constants/proxy";
 import { STATE_RUNNING } from "@/constants/transfer-process";
 import { ASSET_TITLE } from "@/jsonld/asset";
+import { EnrichedContractAgreement } from "@/types/enriched-contract-agreement";
+import { cache } from "@/utilities/cache";
 import {
   AGREEMENT_RETIREMENT_DATE,
   AGREEMENT_RETIREMENT_REASON,
@@ -8,22 +11,15 @@ import {
 } from "@/utilities/contract-agreement";
 import { operatorIn } from "@/utilities/data-offer";
 import {
+  Catalog,
   ContractAgreement,
   CriterionInput,
   EdcConnectorClient,
+  expand,
   QuerySpec,
   TransferProcessStates,
 } from "@think-it-labs/edc-connector-client";
 import { NextRequest, NextResponse } from "next/server";
-
-const EDC_NAMESPACE = {
-  IS_TERMINATED: "https://w3id.org/edc/v0.0.1/ns/isTerminated",
-  IS_RUNNING: "https://w3id.org/edc/v0.0.1/ns/isRunning",
-  TRANSFER_COUNT: "https://w3id.org/edc/v0.0.1/ns/transferCount",
-  IS_TERMINATED_AT: "https://w3id.org/edc/v0.0.1/ns/isTerminatedAt",
-  RETIREMENT_REASON: "https://w3id.org/edc/v0.0.1/ns/terminatedReason",
-  ASSET_TITLE: "https://w3id.org/edc/v0.0.1/ns/assetTitle",
-} as const;
 
 // TODO: to be moved
 function connectorApiKey() {
@@ -32,6 +28,11 @@ function connectorApiKey() {
 
 function connectorManagementUrl() {
   return process.env.EDC_MANAGEMENT_URL || "";
+}
+
+function connectorId() {
+  if (!process.env.EDC_ID) throw new Error("Connector ID is missing");
+  return process.env.EDC_ID;
 }
 
 const client = new EdcConnectorClient.Builder()
@@ -51,35 +52,33 @@ const enrichContractAgreement = (
   contractAgreementInfo: Record<string, ContractAgreementInfo>,
   assetTitleMap: Map<string, string>,
 ) => {
-  return {
-    ...contractAgreement,
-    [EDC_NAMESPACE.IS_TERMINATED]:
-      retiredContractAgreementIds.includes(contractAgreement.id) || false,
-    [EDC_NAMESPACE.IS_RUNNING]:
-      contractAgreementInfo[contractAgreement.id]?.isRunning || false,
-    [EDC_NAMESPACE.TRANSFER_COUNT]:
-      contractAgreementInfo[contractAgreement.id]?.transfersCount || 0,
-    [EDC_NAMESPACE.IS_TERMINATED_AT]:
-      contractAgreementInfo[contractAgreement.id]?.isTerminatedAt || 0,
-    [EDC_NAMESPACE.RETIREMENT_REASON]:
-      contractAgreementInfo[contractAgreement.id]?.retirementReason || "",
-    [EDC_NAMESPACE.ASSET_TITLE]:
-      assetTitleMap.get(contractAgreement.assetId) || null,
-  };
+  return expand(
+    {
+      ...contractAgreement,
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.IS_TERMINATED]:
+        retiredContractAgreementIds.includes(contractAgreement.id) || false,
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.IS_RUNNING]:
+        contractAgreementInfo[contractAgreement.id]?.isRunning || false,
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.TRANSFER_COUNT]:
+        contractAgreementInfo[contractAgreement.id]?.transfersCount || 0,
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.IS_TERMINATED_AT]:
+        contractAgreementInfo[contractAgreement.id]?.isTerminatedAt || 0,
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.RETIREMENT_REASON]:
+        contractAgreementInfo[contractAgreement.id]?.retirementReason || "",
+      [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.ASSET_TITLE]:
+        assetTitleMap.get(contractAgreement.assetId) || null,
+    },
+    () => new EnrichedContractAgreement(),
+  );
 };
 
 const shouldIncludeAgreement = (
-  contractAgreement: {
-    "https://w3id.org/edc/v0.0.1/ns/isTerminated": boolean;
-    "https://w3id.org/edc/v0.0.1/ns/isRunning": boolean;
-    "https://w3id.org/edc/v0.0.1/ns/transferCount": number;
-    "@id": string;
-  },
+  contractAgreement: EnrichedContractAgreement,
   statusFilter: CriterionInput | null,
 ) => {
   //NOTE: this is inefficient and should be replace when this is closed https://github.com/eclipse-edc/Connector/issues/5132
   if (statusFilter && !statusFilter.operandRight) {
-    return !contractAgreement[EDC_NAMESPACE.IS_TERMINATED];
+    return !contractAgreement.isTerminated;
   }
   return true;
 };
@@ -238,16 +237,92 @@ const handleContractAgreementsQuery = async (
       ]),
     );
 
-    const result = contractAgreements
-      .map((agreement) =>
-        enrichContractAgreement(
-          agreement,
-          retiredContractAgreementIds,
-          contractAgreementInfo,
-          assetIdTitleMap,
+    const finalContractAgreements = (
+      await Promise.all(
+        contractAgreements.map((agreement) =>
+          enrichContractAgreement(
+            agreement,
+            retiredContractAgreementIds,
+            contractAgreementInfo,
+            assetIdTitleMap,
+          ),
         ),
       )
-      .filter((agreement) => shouldIncludeAgreement(agreement, statusFilter));
+    ).filter((agreement) => shouldIncludeAgreement(agreement, statusFilter));
+
+    // get contracts with no asset title
+    const foreignContracts = contractAgreements.filter(
+      (ca) => ca.providerId !== connectorId(),
+    );
+    // group assets by connector id
+    const connectorContractsMap = Map.groupBy(
+      foreignContracts,
+      (ca) => ca.providerId,
+    );
+    // fetch connector dsp
+    const dsps = await Promise.all(
+      Array.from(connectorContractsMap, async ([connectorId, cas]) => [
+        connectorId,
+        await cache.get(
+          connectorId,
+          async () =>
+            (
+              await client.management.contractAgreements.getNegotiation(
+                cas[0].id,
+              )
+            ).optionalValue("edc", "counterPartyAddress") as string,
+        ),
+      ]),
+    );
+    // fetch the asset titles using the dsp
+    const assetsConnectorMap = await Promise.all(
+      dsps.map(async ([connectorId, dsp]): Promise<[string, Catalog]> => {
+        return [
+          connectorId,
+          await client.management.catalog.request({
+            counterPartyAddress: dsp,
+            querySpec: {
+              limit: 1000,
+              offset: 0,
+              filterExpression: [
+                {
+                  operandLeft: "id",
+                  operator: "in",
+                  operandRight: connectorContractsMap
+                    .get(connectorId)
+                    ?.map((ca) => ca.assetId),
+                },
+              ],
+            },
+          }),
+        ];
+      }),
+    );
+
+    const catalogConnectorMap = new Map(
+      assetsConnectorMap.flatMap(([connectorId, catalog]) => {
+        return catalog.datasets.map((dataset) => {
+          return [
+            `${connectorId}-${dataset.id}`,
+            dataset["http://purl.org/dc/terms/title"]?.[0]?.["@value"] as
+              | string
+              | undefined,
+          ];
+        });
+      }),
+    );
+
+    // enrich all the contracts
+    const result = finalContractAgreements.map((ca) => {
+      if (!ca.assetTitle) {
+        ca.setValue(
+          "edc",
+          "assetTitle",
+          catalogConnectorMap.get(`${ca.providerId}-${ca.assetId}`) || null,
+        );
+      }
+      return ca;
+    });
 
     return new NextResponse(JSON.stringify(result), { status: 200 });
   } catch (error) {

--- a/src/components/organisms/contract-agreement-card.tsx
+++ b/src/components/organisms/contract-agreement-card.tsx
@@ -46,7 +46,7 @@ export default function ContractAgreementCard({
   );
   const assetTitle =
     contractAgreement.optionalValue<string>("edc", "assetTitle") ||
-    "No Title!!";
+    contractAgreement.assetId;
 
   const isConsumer = contractAgreement.consumerId === connector.id;
   const Icon =

--- a/src/components/organisms/contract-agreement-dialog.tsx
+++ b/src/components/organisms/contract-agreement-dialog.tsx
@@ -4,6 +4,7 @@ import ContractAgreementTerminateDialog from "@/components/organisms/contract-ag
 import { TransferFormDialog } from "@/components/templates/transfer-form-dialog";
 import { TERMINATION_REASON_BY_USER } from "@/constants/contract-agreement.ts";
 import { T } from "@/i18n";
+import { EnrichedContractAgreement } from "@/types/enriched-contract-agreement";
 import {
   datasetToAsset,
   removeJsonLdSchemaFromProperties,
@@ -31,7 +32,7 @@ import { enqueueSnackbar } from "notistack";
 import { useCallback, useEffect, useState } from "react";
 
 interface ContractAgreementDialogProps {
-  contractAgreement: ContractAgreement;
+  contractAgreement: EnrichedContractAgreement;
   open: boolean;
   onClose: () => void;
   participantId: string;
@@ -55,33 +56,14 @@ export default function ContractAgreementDialog({
   onTerminateSuccess = () => {},
   onInitSuccess = () => {},
 }: ContractAgreementDialogProps) {
-  const retirementReason = contractAgreement.optionalValue<string>(
-    "edc",
-    "terminatedReason",
-  );
-  const isTerminated = contractAgreement.optionalValue<boolean>(
-    "edc",
-    "isTerminated",
-  );
-  const isRunning = contractAgreement.optionalValue<boolean>(
-    "edc",
-    "isRunning",
-  );
-  const isTerminatedAt = contractAgreement.optionalValue<number>(
-    "edc",
-    "isTerminatedAt",
-  );
-  const providerId = contractAgreement.optionalValue<string>(
-    "edc",
-    "providerId",
-  );
+  const assetTitle = contractAgreement.assetId || contractAgreement.assetId;
 
-  const assetTitle =
-    contractAgreement.optionalValue<string>("edc", "assetTitle") ||
-    "No Title!!";
-
-  const canTransfer = participantId !== providerId && !isTerminated;
-  const canTerminate = participantId !== providerId && !isTerminated;
+  const canTransfer =
+    participantId !== contractAgreement.providerId &&
+    !contractAgreement.isTerminated;
+  const canTerminate =
+    participantId !== contractAgreement.providerId &&
+    !contractAgreement.isTerminated;
 
   const [isTransferModalOpen, setIsTransferModalOpen] = useState(false);
   const [isTerminateModalOpen, setIsTerminateModalOpen] = useState(false);
@@ -193,10 +175,14 @@ export default function ContractAgreementDialog({
         <DialogTitle>
           <TitleWithIcon
             icon={
-              <Icon fontSize="large" color={isTerminated ? "error" : "inherit"}>
+              <Icon
+                fontSize="large"
+                color={contractAgreement.isTerminated ? "error" : "inherit"}
+              >
                 {(contractAgreement.consumerId === participantId
                   ? "file_download"
-                  : "file_upload") + (isTerminated ? "_off" : "")}
+                  : "file_upload") +
+                  (contractAgreement.isTerminated ? "_off" : "")}
               </Icon>
             }
             title={assetTitle}
@@ -205,9 +191,9 @@ export default function ContractAgreementDialog({
         </DialogTitle>
         <DialogContent style={contentStyle}>
           <div className="flex flex-col gapy-y-3">
-            {isRunning && <LinearProgress className="my-3" />}
+            {contractAgreement.isRunning && <LinearProgress className="my-3" />}
 
-            {isTerminated && (
+            {contractAgreement.isTerminated && (
               <div className="flex gap-x-3 p-4 mb-3 rounded bg-red-50">
                 <svg
                   viewBox="0 0 20 20"
@@ -225,15 +211,15 @@ export default function ContractAgreementDialog({
                   <Typography variant="subtitle1" className="text-red-800">
                     {TERMINATION_REASON_BY_USER}
                   </Typography>
-                  {retirementReason && (
+                  {contractAgreement.retirementReason && (
                     <Typography variant="body2" className="text-red-800">
-                      {retirementReason}
+                      {contractAgreement.retirementReason}
                     </Typography>
                   )}
-                  {!!isTerminatedAt && (
+                  {!!contractAgreement.isTerminatedAt && (
                     <Typography variant="body2" className="text-red-800">
                       <Timestamp
-                        milliseconds={isTerminatedAt}
+                        milliseconds={contractAgreement.isTerminatedAt}
                         year="numeric"
                         month="2-digit"
                         day="2-digit"

--- a/src/constants/contract-agreement.ts
+++ b/src/constants/contract-agreement.ts
@@ -1,2 +1,11 @@
 export const TERMINATION_REASON_BY_USER = "Terminated by user";
 export const TERMINATION_DETAILED_REASON_MAX_LENGTH = 1000;
+
+export const CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS = {
+  IS_TERMINATED: "https://w3id.org/edc/v0.0.1/ns/isTerminated",
+  IS_RUNNING: "https://w3id.org/edc/v0.0.1/ns/isRunning",
+  TRANSFER_COUNT: "https://w3id.org/edc/v0.0.1/ns/transferCount",
+  IS_TERMINATED_AT: "https://w3id.org/edc/v0.0.1/ns/isTerminatedAt",
+  RETIREMENT_REASON: "https://w3id.org/edc/v0.0.1/ns/terminatedReason",
+  ASSET_TITLE: "https://w3id.org/edc/v0.0.1/ns/assetTitle",
+} as const;

--- a/src/types/enriched-contract-agreement.ts
+++ b/src/types/enriched-contract-agreement.ts
@@ -1,0 +1,31 @@
+import { ContractAgreement } from "@think-it-labs/edc-connector-client";
+
+export class EnrichedContractAgreement extends ContractAgreement {
+  constructor() {
+    super();
+  }
+
+  get isTerminated(): boolean | undefined {
+    return this.optionalValue("edc", "isTerminated");
+  }
+
+  get isRunning(): boolean | undefined {
+    return this.optionalValue("edc", "isRunning");
+  }
+
+  get transferCount(): number | undefined {
+    return this.optionalValue("edc", "transferCount");
+  }
+
+  get isTerminatedAt(): number | undefined {
+    return this.optionalValue("edc", "isTerminatedAt");
+  }
+
+  get retirementReason(): string | undefined {
+    return this.optionalValue("edc", "retirementReason");
+  }
+
+  get assetTitle(): string | null | undefined {
+    return this.optionalValue("edc", "assetTitle");
+  }
+}

--- a/src/utilities/cache.ts
+++ b/src/utilities/cache.ts
@@ -1,0 +1,33 @@
+export default class CacheService {
+  private cache = new Map<string, string>();
+  private static instance: CacheService | null = null;
+
+  public static getInstance() {
+    if (!CacheService.instance) {
+      CacheService.instance = new CacheService();
+    }
+    return CacheService.instance;
+  }
+
+  set(key: string, data: string): void {
+    this.cache.set(key, data);
+  }
+
+  async get(key: string, callback: () => Promise<string>) {
+    const entry = this.cache.get(key);
+
+    if (!entry) {
+      const newEntry = await callback();
+      this.set(key, newEntry);
+      return newEntry;
+    }
+
+    return entry;
+  }
+
+  delete(key: string) {
+    this.cache.delete(key);
+  }
+}
+
+export const cache = CacheService.getInstance();


### PR DESCRIPTION
This works only for providing contract agreements.
Consuming contract agreements requires 2 additional requests for each counterparty:
using agreement Id request /api/management/v3/contractagreements/:id/negotiation
from the response take counterPartyAddress and request /api/management/v3/catalog/request

This has to be repeated for each counterparty