### PR TITLE
fix: add retirement reason and date to enrich function

### DIFF
--- a/src/app/connector/management/v3/contractagreements/[...path]/route.ts
+++ b/src/app/connector/management/v3/contractagreements/[...path]/route.ts
@@ -64,12 +64,15 @@ const enrichContractAgreement = (
         contractAgreementInfo[contractAgreement.id]?.transfersCount || 0,
       [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.IS_TERMINATED_AT]:
         contractAgreementInfo[contractAgreement.id]?.isTerminatedAt ||
-        retiredContractAgreementMap.get(contractAgreement.id)?.isTerminatedAt ||
+        retiredContractAgreementMap.get(contractAgreement.id)?.[
+          AGREEMENT_RETIREMENT_DATE
+        ] ||
         0,
       [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.RETIREMENT_REASON]:
         contractAgreementInfo[contractAgreement.id]?.retirementReason ||
-        retiredContractAgreementMap.get(contractAgreement.id)
-          ?.retirementReason ||
+        retiredContractAgreementMap.get(contractAgreement.id)?.[
+          AGREEMENT_RETIREMENT_REASON
+        ] ||
         "",
       [CONTRACT_AGREEMENT_EDC_NAMESPACE_KEYS.ASSET_TITLE]:
         assetTitleMap.get(contractAgreement.assetId) || null,


### PR DESCRIPTION
This pr builds on #394 to fix the #358 
The issue was that when a contract agreement was retired before any transfer processes have been made the data location changes from transferProcess to retirementAgrement.
closes #358 