### PR TITLE
Update default policy name

### DIFF
--- a/src/pages/create-data-offer/index.tsx
+++ b/src/pages/create-data-offer/index.tsx
@@ -319,7 +319,7 @@ export default function CreateDataOfferPage() {
         if (publishMode === PUBLISH_MODE_PUBLISH_RESTRICTED.value) {
           // create policy
           client.management.policyDefinitions
-            .create(fromPolicyDefinitionForm(policyExpression, ""))
+            .create(fromPolicyDefinitionForm(policyExpression, formData.asset["@id"]))
             .then((result) => {
               formData.contract.accessPolicyId = result["@id"];
               formData.contract.contractPolicyId = result["@id"];

--- a/src/utilities/policy.ts
+++ b/src/utilities/policy.ts
@@ -10,7 +10,7 @@ export const defaultCreatePolicyFormData: PolicyDefinitionInput = {
   policy: defaultPolicy
 };
 
-export const fromPolicyDefinitionForm = (formData: Constraint[], id:string) : PolicyDefinitionInput => {
+export const fromPolicyDefinitionForm = (formData: Constraint[], id?:string) : PolicyDefinitionInput => {
   const policy = new PolicyBuilder().type("Set").raw({
     permission: [
       {


### PR DESCRIPTION
### Description
- What you create a Data Offer, the policy name is a UUI instead of the name of the Asset
- This PR makes the asset name equal to the policy name


closes https://github.com/Mobility-Data-Space/mds-edc-ui/issues/437