### PR TITLE
fix: update refetch event name to use correct format {entity-name}-list-refetch

### DIFF
--- a/src/components/organisms/asset-form.tsx
+++ b/src/components/organisms/asset-form.tsx
@@ -20,10 +20,7 @@ import { AssetFormGeneralInfoStepContent } from "@/components/organisms/asset-fo
 import { Snackbar } from "@/components/molecules/snackbar";
 import { useParticipantConnectorState } from "@/hooks/use-participant-connector-state";
 import { T, useTranslator } from "@/i18n";
-import {
-  ASSET_TITLE,
-  ASSET_VERSION,
-} from "@/jsonld/asset";
+import { ASSET_TITLE, ASSET_VERSION } from "@/jsonld/asset";
 import {
   AssetProperties,
   defaultCreateAssetFormData,
@@ -177,8 +174,6 @@ export default function AssetForm({ onClose }: AssetFormProps) {
     return onChange({ ...formData, properties: advancedInfoFormData });
   };
 
-  
-
   const setFormErrors = () => {
     return {
       properties: validateAdvancedInfo(
@@ -249,7 +244,7 @@ export default function AssetForm({ onClose }: AssetFormProps) {
               />
             ),
           });
-          window.dispatchEvent(new Event("list-refetch"));
+          window.dispatchEvent(new Event("assets-list-refetch"));
           onClose();
         }}
         formData={() => fromAssetForm(formData, connector.curatorName)}

--- a/src/pages/contract-agreements/index.tsx
+++ b/src/pages/contract-agreements/index.tsx
@@ -133,10 +133,10 @@ export default function ContractAgreementsListPage() {
           contractAgreement={openContractAgreementData}
           onClose={() => setIsDetailsModalOpen(false)}
           onInitSuccess={() => {
-            window.dispatchEvent(new Event("list-refetch"));
+            window.dispatchEvent(new Event("contract-agreements-list-refetch"));
           }}
           onTerminateSuccess={() => {
-            window.dispatchEvent(new Event("list-refetch"));
+            window.dispatchEvent(new Event("contract-agreements-list-refetch"));
             enqueueSnackbar(
               translator("contractAgreements.terminationSuccess"),
               {

--- a/src/pages/policy-definitions/new.tsx
+++ b/src/pages/policy-definitions/new.tsx
@@ -20,16 +20,23 @@ export default function CreatePolicyDefinitionPage() {
 
   const { translator } = useTranslator();
 
-  const [formData, setFormData] = useState<(AtomicConstraint|MultiplicityConstraint)[]>([]);
-  const [policyId, setPolicyId] = useState("") ;
-  const [policyExpression, setPolicyExpression] = useState<(AtomicConstraint|MultiplicityConstraint)[]>([]);
+  const [formData, setFormData] = useState<
+    (AtomicConstraint | MultiplicityConstraint)[]
+  >([]);
+  const [policyId, setPolicyId] = useState("");
+  const [policyExpression, setPolicyExpression] = useState<
+    (AtomicConstraint | MultiplicityConstraint)[]
+  >([]);
 
-  const validateForm = () => true ;
-  const onChange = (newFormData: (AtomicConstraint|MultiplicityConstraint)[], policyId:string) => {
-    setFormData([ ...newFormData ]);
-    setPolicyExpression([ ...newFormData ]);
+  const validateForm = () => true;
+  const onChange = (
+    newFormData: (AtomicConstraint | MultiplicityConstraint)[],
+    policyId: string,
+  ) => {
+    setFormData([...newFormData]);
+    setPolicyExpression([...newFormData]);
     setPolicyId(policyId);
-  }
+  };
   const onSubmit = () => {
     if (!validateForm()) {
       return;
@@ -41,8 +48,10 @@ export default function CreatePolicyDefinitionPage() {
   };
 
   const onFormSubmitFail = (error: Error) => {
-    const match = /"message":"(.*?)"/.exec(error.message)
-    enqueueSnackbar((match && match[1]) || translator("policyDefinition.new.saveFail"));
+    const match = /"message":"(.*?)"/.exec(error.message);
+    enqueueSnackbar(
+      (match && match[1]) || translator("policyDefinition.new.saveFail"),
+    );
   };
 
   if (!connector) {
@@ -60,13 +69,15 @@ export default function CreatePolicyDefinitionPage() {
               content: (key) => (
                 <Snackbar
                   type="success"
-                  message={translator('policyDefinitions.new.successCreate')}
-                  onClose={() => { closeSnackbar(key); }}
+                  message={translator("policyDefinitions.new.successCreate")}
+                  onClose={() => {
+                    closeSnackbar(key);
+                  }}
                 />
-              )
+              ),
             });
-            window.dispatchEvent(new Event("list-refetch"));
-            setTimeout(() => push("/policy-definitions"), 1000)
+            window.dispatchEvent(new Event("policy-definitions-list-refetch"));
+            setTimeout(() => push("/policy-definitions"), 1000);
           }}
           onFailure={onFormSubmitFail}
         >
@@ -74,10 +85,8 @@ export default function CreatePolicyDefinitionPage() {
             <div className="grid sm:grid-cols-2 gap-2 sm:gap-6">
               <div className="sm:col-span-2 flex flex-col gap-6">
                 <div>
-                  <label
-                    className="inline-block text-sm text-black font-medium mb-2"
-                  >
-                    <T string="policyDefinitions.new.policyId"/>
+                  <label className="inline-block text-sm text-black font-medium mb-2">
+                    <T string="policyDefinitions.new.policyId" />
                   </label>
                   <Input
                     required
@@ -96,11 +105,13 @@ export default function CreatePolicyDefinitionPage() {
               <div className="sm:col-span-2 flex flex-col gap-6">
                 <div>
                   <label className="inline-block text-sm text-black font-medium mb-4">
-                    <T string="policyDefinitions.new.policyExpression"/>
+                    <T string="policyDefinitions.new.policyExpression" />
                   </label>
                   <PolicyExpression
                     value={policyExpression}
-                    onChange={(value) => { onChange(value, policyId) }}
+                    onChange={(value) => {
+                      onChange(value, policyId);
+                    }}
                   />
                 </div>
               </div>


### PR DESCRIPTION
The ui library now requires a specific event name to refresh an entity list in the form of `{entity-name}-list-refetch`
This pr now updates all the refetch events.