### PR TITLE
enable react compiler

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  reactCompiler: true,
   output: "standalone",
   i18n: {
     defaultLocale: "en",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "@types/node": "^24",
     "@types/react": "^19",
     "@types/react-dom": "^18",
+    "babel-plugin-react-compiler": "^1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.0.7",
     "eslint-plugin-playwright": "^2.4.0",

--- a/src/hooks/use-date-format.ts
+++ b/src/hooks/use-date-format.ts
@@ -1,0 +1,15 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { browserDateFormat } from "@/utilities/date";
+
+// Hook to get date format on client side
+export const useDateFormat = () => {
+  const [dateFormat, setDateFormat] = useState<string>("DD/MM/YYYY");
+  
+  useEffect(() => {
+    setDateFormat(browserDateFormat());
+  }, []);
+  
+  return dateFormat;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -143,6 +143,14 @@
     "@babel/types" "^7.28.5"
     debug "^4.3.1"
 
+"@babel/types@^7.26.0":
+  version "7.28.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.6.tgz#c3e9377f1b155005bcc4c46020e7e394e13089df"
+  integrity sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==
+  dependencies:
+    "@babel/helper-string-parser" "^7.27.1"
+    "@babel/helper-validator-identifier" "^7.28.5"
+
 "@babel/types@^7.27.1", "@babel/types@^7.28.4", "@babel/types@^7.28.5":
   version "7.28.5"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.28.5.tgz#10fc405f60897c35f07e85493c932c7b5ca0592b"
@@ -1684,6 +1692,13 @@ babel-plugin-macros@^3.1.0:
     "@babel/runtime" "^7.12.5"
     cosmiconfig "^7.0.0"
     resolve "^1.19.0"
+
+babel-plugin-react-compiler@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-react-compiler/-/babel-plugin-react-compiler-1.0.0.tgz#bdf7360a23a4d5ebfca090255da3893efd07425f"
+  integrity sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==
+  dependencies:
+    "@babel/types" "^7.26.0"
 
 bail@^2.0.0:
   version "2.0.2"


### PR DESCRIPTION
This pr enables react compiler in the project build step, you can read more [here](https://react.dev/learn/react-compiler).
The performance increase is not sustainable, a similar pr for the UI library should allow for a much better performance optimization. UI issue [here](https://github.com/Think-iT-Labs/edc-connector-ui/issues/24)