### PR TITLE
Correct catalog page UI alignment

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "playwright test",
-    "test:ui": "playwright test --ui"
+    "test:ui": "playwright test --ui",
+    "seed:e2e": "ts-node tests/utils/global-setup.ts"
   },
   "dependencies": {
     "@emotion/react": "^11.14.0",

--- a/src/pages/catalog-browser/index.tsx
+++ b/src/pages/catalog-browser/index.tsx
@@ -225,12 +225,11 @@ export default function CatalogPage() {
               ) : (
                 <div
                   className={
-                    "size-full flex flex-col items-center justify-center"
+                    "size-full flex flex-col items-start justify-center"
                   }
                 >
-                  <Icon style={{ fontSize: "0px" }}>info</Icon>
 
-                  <Typography variant="h6" component="h6" color="info">
+                  <Typography variant="h6" fontSize="16px" component="h6" color="info">
                     <T string="catalog.emptyCounterPartyUrl" />
                   </Typography>
                 </div>


### PR DESCRIPTION
### Description

Aligns the Catalog message to to the left 

### Screenshots

<img width="1612" height="555" alt="Screenshot 2026-04-08 at 20 27 20" src="https://github.com/user-attachments/assets/5bb7ffb1-a29f-450b-b797-3708c26541ae" />


### Issues

https://github.com/Mobility-Data-Space/mds-edc-ui/issues/586
