### PR TITLE
fix(deps): bump nanoid and undici to unblock Trivy security scan

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,9 +55,10 @@
     "i18next-fs-backend": ">=2.6.4",
     "lodash": ">=4.18.0",
     "lodash-es": ">=4.18.0",
+    "nanoid": "^3.3.17",
     "postcss": ">=8.5.18",
     "sharp": ">=0.35.0",
-    "undici": ">=8.5.0",
+    "undici": ">=8.9.0",
     "yaml": ">=1.10.3"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4086,10 +4086,10 @@ mui-chips-input@^9.0.0:
   resolved "https://registry.yarnpkg.com/mui-chips-input/-/mui-chips-input-9.0.0.tgz#d7dc990711a14b8afc5793674dbd43198fd763bc"
   integrity sha512-2GSHSK6fp+s6fJWEEMUsYIecgy6Iy6AzB1/7CM048a3GERzDJMbebTYdQbaokpCyx+Fg4mh7yGLRcO5O/yEYFg==
 
-nanoid@^3.3.16:
-  version "3.3.16"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.16.tgz#a04d8ec4b1f10009d2d533947aefe4293737816c"
-  integrity sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==
+nanoid@^3.3.16, nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.18.tgz#f66a2de1199ffde0fcf21c8a5f13106b1c081913"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
 
 napi-postinstall@^0.3.0:
   version "0.3.4"
@@ -5216,10 +5216,10 @@ undici-types@~8.3.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-8.3.0.tgz#44e9fc9f3244648cdea35e4f9bb2d681e9410809"
   integrity sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==
 
-undici@>=8.5.0, undici@^6.23.0:
-  version "8.5.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-8.5.0.tgz#31ba9021a3d84c15e61cc5e28be2d7c451e66a66"
-  integrity sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==
+undici@>=8.9.0, undici@^6.23.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-8.10.0.tgz#67ed7c4087f0f40fba7bef3a46f2be80572f2473"
+  integrity sha512-HvltHd7avK13QIw/oLe4qoOLyoVSoafqJ2jYOrtMRBkbYT31eiBQ8O0ehRKZiEZCMEyLFQNIADpgCWC5fALvYQ==
 
 unified@^11.0.0:
   version "11.0.5"


### PR DESCRIPTION
The `Security Scan` workflow fails on `main` and on every open PR, blocking all of them. Trivy reports 2 HIGH findings in `yarn.lock`, both with fixes available (`ignore-unfixed: true`, so the gate is behaving correctly — the lockfile is just behind):

| Package | CVE | Installed | Fixed in |
|---|---|---|---|
| `nanoid` (transitive, via `postcss`) | CVE-2026-67213 — infinite loop in `customAlphabet` | 3.3.16 | 3.3.17 |
| `undici` | CVE-2026-13697 — information disclosure and DoS via malformed `Cache-Control` directives | 8.5.0 | 8.9.0 |

Fix: two `resolutions` entries. `nanoid` is pinned with `^3.3.17` rather than the file's usual `>=` style on purpose — `>=3.3.17` resolves to nanoid 6.0.1, which is ESM-only and breaks `postcss`'s CJS `require('nanoid/non-secure')`. The caret keeps it on the 3.x line (3.3.18).

Lockfile churn is limited to those two entries (nanoid 3.3.16 → 3.3.18, undici 8.5.0 → 8.10.0).

Verified locally:
- `trivy fs --scanners vuln,secret --severity HIGH,CRITICAL --ignore-unfixed` → 0 findings (fresh vuln DB)
- `yarn build` → passes

Out of scope, noted while reviewing the failing runs:
- **Periodic Image Rescan** is failing on the published 3.1.0/3.1.1 tags (`next` CVE-2026-64641/64642/64645/64649, `sharp` GHSA-f88m-g3jw-g9cj, plus `tar`/`brace-expansion`/`ip-address` in 3.1.0). Those images are immutable — only a new release clears them. Runs on a schedule, does not block PRs.
- **Verify (Test and Build)** is separately flaky: one run died pulling `mcr.microsoft.com/playwright:v1.61.0-jammy` (exit 125, connection reset), others are e2e timeouts in varying specs.